### PR TITLE
dev

### DIFF
--- a/attestation.go
+++ b/attestation.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tinfoilsh/tfshim/dcode"
 	"github.com/tinfoilsh/verifier/attestation"
+	"github.com/tinfoilsh/verifier/client"
 	"github.com/tinfoilsh/verifier/github"
 	"github.com/tinfoilsh/verifier/sigstore"
 )
@@ -58,7 +59,13 @@ type auditRecord struct {
 
 func verifyAttestation(l *log.Logger) (*auditRecord, error) {
 	if enclaveHost == "" {
-		return nil, fmt.Errorf("enclave host is required")
+		router := client.NewRouter()
+		host, err := router.GetRouter()
+		if err != nil {
+			return nil, fmt.Errorf("getting router: %v", err)
+		}
+		l.Printf("Using auto selected router: %s", host)
+		enclaveHost = host
 	}
 
 	var auditRec auditRecord

--- a/attestation_verify_test.go
+++ b/attestation_verify_test.go
@@ -6,17 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//func TestAttestationVerifyNitro(t *testing.T) {
-//	args := []string{
-//		"attestation",
-//		"verify",
-//		"-e", "models.default.tinfoil.sh",
-//		"-r", "tinfoilsh/default-models-nitro",
-//	}
-//	rootCmd.SetArgs(args)
-//	assert.Nil(t, rootCmd.Execute())
-//}
-
 func TestAttestationVerifySEV(t *testing.T) {
 	args := []string{
 		"attestation",

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tinfoilsh/tfshim v0.1.1
 	github.com/tinfoilsh/tinfoil-go v0.1.2
-	github.com/tinfoilsh/verifier v0.2.5
+	github.com/tinfoilsh/verifier v0.10.1
 	golang.org/x/term v0.34.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1247,6 +1247,8 @@ github.com/tinfoilsh/tinfoil-go v0.1.2 h1:OgOjkx1E2ZlV3/vylC5on34nAMJ6gTfCiBut8P
 github.com/tinfoilsh/tinfoil-go v0.1.2/go.mod h1:lSAFoTzRCBzOi1eXTkvmAi/eOhpI3zjBZiRGIFneHw8=
 github.com/tinfoilsh/verifier v0.2.5 h1:LklaMHt8KmaJ218c6WXXvPNi69SY3QoSQQWQh47Erlk=
 github.com/tinfoilsh/verifier v0.2.5/go.mod h1:+PZ/SrEnw2rwNogEblUpyxQahEYKo+zVS7dN198waU4=
+github.com/tinfoilsh/verifier v0.10.1 h1:lXiYqQMcJzKleDc1eKdA2SGfsB/FT0G0QuP12m/g+OM=
+github.com/tinfoilsh/verifier v0.10.1/go.mod h1:+PZ/SrEnw2rwNogEblUpyxQahEYKo+zVS7dN198waU4=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0 h1:N9UxlsOzu5mttdjhxkDLbzwtEecuXmlxZVo/ds7JKJI=
 github.com/tink-crypto/tink-go-awskms/v2 v2.1.0/go.mod h1:PxSp9GlOkKL9rlybW804uspnHuO9nbD98V/fDX4uSis=
 github.com/tink-crypto/tink-go-gcpkms/v2 v2.2.0 h1:3B9i6XBXNTRspfkTC0asN5W0K6GhOSgcujNiECNRNb0=


### PR DESCRIPTION
from dev
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds automatic router selection in attestation verification when no enclave host is provided, so the command works without manual configuration. Updates the verifier dependency to v0.10.1.

- **New Features**
  - If enclaveHost is empty, auto-select a router via verifier/client and log the chosen host.

- **Dependencies**
  - Bump github.com/tinfoilsh/verifier to v0.10.1.

<!-- End of auto-generated description by cubic. -->

