### PR TITLE
feat: manage new hpke and attestation encoding format

### DIFF
--- a/attestation.go
+++ b/attestation.go
@@ -163,6 +163,7 @@ func verifyAttestation(l *log.Logger) (*auditRecord, error) {
 			if err != nil {
 				return nil, fmt.Errorf("verifying attestation: %v", err)
 			}
+			l.Debugf("Attestation sucessfully exctracted from certificate: %v", dcodeAttestationMaterial.Measurement.Type)
 			auditRec.Keys.Cert = dcodeAttestationMaterial.TLSPublicKeyFP
 			auditRec.Measurements.Cert = dcodeAttestationMaterial.TLSPublicKeyFP
 		} else {


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add support for the new SAN-based HPKE and attestation encoding. The verifier now extracts and validates attestations from .att.tinfoil.sh SANs and logs grouped domains for debugging.

- **New Features**
  - Parse SANs by suffix into hpke (.hpke.tinfoil.sh), attestation (.att.tinfoil.sh), and hashed attestation (.hatt.tinfoil.sh) groups.
  - Decode and verify attestations from .att.tinfoil.sh; update auditRec with the TLS public key fingerprint.
  - Add debug logs for DNSNames and grouped domains.

- **Refactors**
  - Replace the “drop last SAN” heuristic with explicit suffix-based parsing for the new format.

<sup>Written for commit 721dda56b601863acfc06b524f374c0b9ad1025e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



