### PR TITLE
chore: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,7 @@ All models are now accessed through the Tinfoil inference proxy. The `config.jso
 - `llama` → `llama3-3-70b`
 - `deepseek` → `deepseek-r1-0528`
 - `terminus` → `deepseek-v31-terminus`
-- `mistral` → `mistral-small-3-1-24b`
-- `qwen` → `qwen2-5-72b`
 - `gpt-oss` → `gpt-oss-120b`
-- `tts` → `kokoro`
 - `whisper` → `whisper-large-v3-turbo`
 - `embed` → `nomic-embed-text`
 
@@ -318,4 +315,4 @@ Please report security vulnerabilities by either:
 
 - Opening an issue on GitHub on this repository
 
-We aim to respond to security reports within 24 hours and will keep you updated on our progress.
+We aim to respond to (legitimate) security reports within 24 hours.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated README to remove outdated model alias mappings and tighten the security policy wording. Removed aliases for mistral, qwen, and tts; clarified that we respond to legitimate security reports within 24 hours.

<sup>Written for commit 094f5c5d89a2e9f7d2767bf5ee95b51b83343c36. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

