### PR TITLE
fix: stale repo name

### DIFF
--- a/inference.go
+++ b/inference.go
@@ -22,7 +22,7 @@ import (
 // Proxy constants - all inference requests go through this proxy
 const (
 	PROXY_ENCLAVE = "inference.tinfoil.sh"
-	PROXY_REPO    = "tinfoilsh/confidential-inference-proxy"
+	PROXY_REPO    = "tinfoilsh/confidential-model-router"
 )
 
 //go:embed config.json


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated PROXY_REPO to tinfoilsh/confidential-model-router to fix a stale repo reference in the inference proxy.
Ensures the proxy points to the correct repository in logs and metadata.

<sup>Written for commit 3308d3acf5f9fa3a6f53afe7378552e6a48c75ff. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

