### PR TITLE
feat: add -b/--bind flag to proxy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,15 @@ tinfoil proxy \
   -p 8080
 ```
 
+### Command Options
+
+- `-p, --port`: Port to listen on. Defaults to `8080`.
+- `-b, --bind`: Address to bind to. Defaults to `127.0.0.1`.
+- `-e, --host`: The hostname of the enclave.
+- `-r, --repo`: The GitHub repository containing code measurements.
+
+By default, the proxy binds to `127.0.0.1` (localhost only). To expose the proxy on all interfaces, use `-b 0.0.0.0`.
+
 ## Docker
 
 A docker image is available at `ghcr.io/tinfoilsh/tinfoil-cli`.

--- a/proxy.go
+++ b/proxy.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -13,11 +14,13 @@ import (
 
 var (
 	listenPort uint
+	listenAddr string
 )
 
 func init() {
 	rootCmd.AddCommand(proxyCmd)
 	proxyCmd.Flags().UintVarP(&listenPort, "port", "p", 8080, "Port to listen on")
+	proxyCmd.Flags().StringVarP(&listenAddr, "bind", "b", "127.0.0.1", "Address to bind to")
 }
 
 var proxyCmd = &cobra.Command{
@@ -69,7 +72,8 @@ var proxyCmd = &cobra.Command{
 			}
 		})
 
-		log.Infof("Starting HTTP proxy on %d", listenPort)
-		return http.ListenAndServe(fmt.Sprintf(":%d", listenPort), nil)
+		addr := net.JoinHostPort(listenAddr, strconv.FormatUint(uint64(listenPort), 10))
+		log.Infof("Starting HTTP proxy on %s", addr)
+		return http.ListenAndServe(addr, nil)
 	},
 }


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add -b/--bind flag to the proxy command to configure the listen address. Default is 127.0.0.1; use 0.0.0.0 to expose the proxy on all interfaces.

<sup>Written for commit de48a79566be4c3d787b27c6aa34e61d316ed181. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



