### PR TITLE
chore: update config to include kimi and voxtral

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,6 @@
 {
+  "kimi-k2-5": "kimi-k2-5",
+  "kimi-k25": "kimi-k2-5",
   "kimi-k2-thinking": "kimi-k2-thinking",
   "kimi": "kimi-k2-thinking",
   "deepseek-r1-0528": "deepseek-r1-0528",
@@ -15,6 +17,8 @@
   "qwen3-vl": "qwen3-vl-30b",
   "whisper-large-v3-turbo": "whisper-large-v3-turbo",
   "whisper": "whisper-large-v3-turbo",
+  "voxtral-small-24b": "voxtral-small-24b",
+  "voxtral": "voxtral-small-24b",
   "nomic-embed-text": "nomic-embed-text",
   "embed": "nomic-embed-text"
 }

--- a/inference.go
+++ b/inference.go
@@ -170,8 +170,8 @@ var audioCmd = &cobra.Command{
 			log.Fatalf("Please specify an audio file using the -f flag")
 		}
 
-		if !strings.HasPrefix(modelName, "whisper") {
-			log.Fatalf("Invalid model. Must use a whisper model for audio transcription")
+		if !strings.HasPrefix(modelName, "whisper") && !strings.HasPrefix(modelName, "voxtral") {
+			log.Fatalf("Invalid model. Must use a whisper or voxtral model for audio transcription")
 		}
 
 		if enclaveHost == "" || repo == "" {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added Kimi K2-5 and Voxtral to the model config and enabled Voxtral for audio transcription in the CLI. This adds new aliases and expands supported audio models beyond Whisper.

- **New Features**
  - Config aliases: "kimi-k2-5" and "kimi-k25" → kimi-k2-5; "voxtral-small-24b" and "voxtral" → voxtral-small-24b.
  - CLI audio: accept models starting with "whisper" or "voxtral"; updated validation message.

<sup>Written for commit 1ec3aaecb442ca53163bb7654b73e86e5c87a78c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

