### PR TITLE
chore: fix tests following sdk update

### DIFF
--- a/attestation.go
+++ b/attestation.go
@@ -95,7 +95,7 @@ func verifyAttestation(l *log.Logger) (*auditRecord, error) {
 		}
 
 		l.Println("Verifying code measurements")
-		codeMeasurements, err = sigstore.VerifyAttestation(trustRootJSON, bundleBytes, digest, repo)
+		codeMeasurements, err = sigstore.VerifyAttestation(trustRootJSON, bundleBytes, repo, digest)
 		if err != nil {
 			return nil, fmt.Errorf("sigstore verify: %v", err)
 		}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the sigstore.VerifyAttestation call to match the new SDK signature (repo before digest). Fixes failing tests and keeps attestation verification working.

<sup>Written for commit 87b5d3c9fb4633beb6ebc73148cd4d477ae63dac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

