### PR TITLE
[codex] Support headers for http requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,12 @@ tinfoil http get https://inference.tinfoil.sh/health \
 tinfoil http post https://inference.tinfoil.sh/v1/chat/completions \
   -e inference.tinfoil.sh \
   -r tinfoilsh/confidential-model-router \
+  -H "Authorization: Bearer $TINFOIL_API_KEY" \
+  -H "Content-Type: application/json" \
   -b '{"model": "deepseek-r1-0528", "messages": [{"role": "user", "content": "Hello"}]}'
 ```
+
+Pass custom request headers with repeatable `-H, --header` flags. Headers are sent through the verified connection after enclave attestation succeeds.
 
 ## Attestation Verification
 

--- a/http.go
+++ b/http.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/spf13/cobra"
 
 	"github.com/tinfoilsh/tinfoil-go/verifier/client"
 )
+
+var requestHeaders []string
 
 func secureClient() *client.SecureClient {
 	return client.NewSecureClient(enclaveHost, repo)
@@ -12,9 +17,46 @@ func secureClient() *client.SecureClient {
 
 func init() {
 	rootCmd.AddCommand(httpCmd)
+	httpCmd.PersistentFlags().StringArrayVarP(&requestHeaders, "header", "H", nil, `HTTP request header ("Name: Value"); may be repeated`)
 }
 
 var httpCmd = &cobra.Command{
 	Use:   "http",
 	Short: "Make verified HTTP requests",
+}
+
+func parseRequestHeaders(headerArgs []string) (map[string]string, error) {
+	if len(headerArgs) == 0 {
+		return nil, nil
+	}
+
+	headers := make(map[string]string, len(headerArgs))
+	for _, raw := range headerArgs {
+		name, value, ok := strings.Cut(raw, ":")
+		if !ok {
+			return nil, fmt.Errorf("invalid header %q: expected \"Name: Value\"", raw)
+		}
+
+		name = strings.TrimSpace(name)
+		value = strings.TrimSpace(value)
+		if name == "" {
+			return nil, fmt.Errorf("invalid header %q: header name cannot be empty", raw)
+		}
+		if strings.ContainsAny(name, "\r\n") || strings.ContainsAny(value, "\r\n") {
+			return nil, fmt.Errorf("invalid header %q: headers cannot contain newlines", raw)
+		}
+
+		headers[name] = value
+	}
+
+	return headers, nil
+}
+
+func hasRequestHeader(headers map[string]string, name string) bool {
+	for headerName := range headers {
+		if strings.EqualFold(headerName, name) {
+			return true
+		}
+	}
+	return false
 }

--- a/http_get.go
+++ b/http_get.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/spf13/cobra"
 )
@@ -15,11 +14,17 @@ var httpGetCmd = &cobra.Command{
 	Use:   "get [url]",
 	Short: "HTTP GET request",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		resp, err := secureClient().Get(args[0], nil)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		headers, err := parseRequestHeaders(requestHeaders)
 		if err != nil {
-			log.Fatal(err)
+			return err
+		}
+
+		resp, err := secureClient().Get(args[0], headers)
+		if err != nil {
+			return err
 		}
 		fmt.Println(string(resp.Body))
+		return nil
 	},
 }

--- a/http_post.go
+++ b/http_post.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/spf13/cobra"
@@ -25,26 +24,36 @@ var httpPostCmd = &cobra.Command{
 	Use:   "post [url]",
 	Short: "HTTP POST request",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		url := args[0]
 		sc := secureClient()
+
+		headers, err := parseRequestHeaders(requestHeaders)
+		if err != nil {
+			return err
+		}
 
 		if stream {
 			// Build a raw HTTP POST request with the provided body.
 			req, err := http.NewRequest("POST", url, bytes.NewBuffer([]byte(body)))
 			if err != nil {
-				log.Fatalf("Error creating request: %v", err)
+				return fmt.Errorf("error creating request: %w", err)
 			}
-			req.Header.Set("Content-Type", "application/json")
+			for k, v := range headers {
+				req.Header.Set(k, v)
+			}
+			if !hasRequestHeader(headers, "Content-Type") {
+				req.Header.Set("Content-Type", "application/json")
+			}
 
 			// Use the verifier’s HTTP client.
 			client, err := sc.HTTPClient()
 			if err != nil {
-				log.Fatalf("Error getting HTTP client: %v", err)
+				return fmt.Errorf("error getting HTTP client: %w", err)
 			}
 			resp, err := client.Do(req)
 			if err != nil {
-				log.Fatalf("Error performing streaming request: %v", err)
+				return fmt.Errorf("error performing streaming request: %w", err)
 			}
 			defer resp.Body.Close()
 
@@ -53,14 +62,16 @@ var httpPostCmd = &cobra.Command{
 				fmt.Println(scanner.Text())
 			}
 			if err := scanner.Err(); err != nil {
-				log.Fatalf("Error reading stream: %v", err)
+				return fmt.Errorf("error reading stream: %w", err)
 			}
 		} else { // Not streaming
-			resp, err := sc.Post(url, nil, []byte(body))
+			resp, err := sc.Post(url, headers, []byte(body))
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 			fmt.Println(string(resp.Body))
 		}
+
+		return nil
 	},
 }

--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRequestHeaders(t *testing.T) {
+	headers, err := parseRequestHeaders([]string{
+		"Authorization: Bearer token",
+		"Content-Type: application/json",
+		"X-Trace: value:with:colons",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"Authorization": "Bearer token",
+		"Content-Type":  "application/json",
+		"X-Trace":       "value:with:colons",
+	}, headers)
+}
+
+func TestParseRequestHeadersReturnsNilForEmptyInput(t *testing.T) {
+	headers, err := parseRequestHeaders(nil)
+
+	require.NoError(t, err)
+	assert.Nil(t, headers)
+}
+
+func TestParseRequestHeadersRejectsMalformedHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers []string
+	}{
+		{
+			name:    "missing colon",
+			headers: []string{"Authorization Bearer token"},
+		},
+		{
+			name:    "empty name",
+			headers: []string{": Bearer token"},
+		},
+		{
+			name:    "newline in value",
+			headers: []string{"Authorization: Bearer token\nX-Other: value"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := parseRequestHeaders(test.headers)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestHasRequestHeaderIgnoresCase(t *testing.T) {
+	assert.True(t, hasRequestHeader(map[string]string{
+		"content-type": "application/json",
+	}, "Content-Type"))
+}


### PR DESCRIPTION
## Summary
- Add repeatable `-H, --header` support to `tinfoil http` requests.
- Pass headers through GET, POST, and streaming POST while preserving the default streaming JSON content type.
- Document authenticated one-off POST usage in the README.

## Validation
- `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds repeatable `-H, --header` support to `tinfoil http` so you can send custom headers with GET, POST, and streaming POST requests. Keeps `Content-Type: application/json` as the default for streaming unless you override it.

- **New Features**
  - Add repeatable `-H, --header` flags to `tinfoil http` (format: "Name: Value"); validated parsing supports colons in values and rejects malformed input.
  - Pass headers through verified connections for GET, POST, and streaming POST; streaming defaults to `Content-Type: application/json` if not provided.
  - README shows an authenticated one-off POST example.

- **Refactors**
  - Switch GET/POST commands to `RunE` and return errors instead of exiting.
  - Add tests for header parsing and case-insensitive header detection.

<sup>Written for commit d2f8fb905c0f8c789d5297fb3afa0307821fc68f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

