### PR TITLE
Manage Tinfoil Containers from the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tinfoil CLI
 
-A command-line interface for verifying Tinfoil enclave attestations and making verified HTTP requests.
+A command-line interface for verifying Tinfoil enclave attestations, making verified HTTP requests, and managing the lifecycle of Tinfoil Containers.
 
 [![Documentation](https://img.shields.io/badge/docs-tinfoil.sh-blue)](https://docs.tinfoil.sh/sdk/cli-sdk)
 
@@ -11,6 +11,89 @@ curl -fsSL https://github.com/tinfoilsh/tinfoil-cli/raw/main/install.sh | sh
 ```
 
 Or download a binary from the [Releases](https://github.com/tinfoilsh/tinfoil-cli/releases) page. A Docker image is also available at `ghcr.io/tinfoilsh/tinfoil-cli`.
+
+## Container management
+
+The `container`, `secret`, `ssh-key`, `registry`, and `domain` subcommands manage Tinfoil Containers through the same controlplane API the dashboard uses.
+
+### Logging in
+
+Create an admin API key from the Tinfoil dashboard (Settings → API Keys → Admin keys). Admin keys are scoped to a single organization, so the CLI inherits that organization automatically.
+
+```bash
+tinfoil login                        # prompts for the key
+tinfoil login --api-key admin_xxx    # non-interactive
+tinfoil whoami                       # confirm the credential and show org context
+tinfoil logout                       # delete saved credentials
+```
+
+Credentials are written to `~/.tinfoil/config.json` (mode 0600). Override on a per-command basis with `TINFOIL_API_KEY` and `TINFOIL_CONTROLPLANE_URL`.
+
+### Containers
+
+```bash
+# Inspect what's deployed
+tinfoil container list
+tinfoil container get my-container
+tinfoil container hosts             # which hosts your org may target
+
+# Deploy
+tinfoil container create my-container \
+  --repo screenpipe/my-repo-container \
+  --tag v1.2.3 \
+  --variable LOG_LEVEL=info \
+  --secret OPENAI_API_KEY \
+  --custom-domain api.example.com
+
+# Lifecycle
+tinfoil container stop my-container
+tinfoil container start my-container --tag v1.2.4
+tinfoil container relaunch my-container --variable LOG_LEVEL=debug
+tinfoil container delete my-container
+
+# Updates
+tinfoil container update status my-container
+tinfoil container update accept my-container
+tinfoil container update cancel my-container
+
+# Auto-update (GitHub-connected containers)
+tinfoil container auto-update my-container --on
+tinfoil container auto-update my-container --off
+
+# Open a verified proxy to a deployed container
+tinfoil container connect my-container -p 8080
+```
+
+`container connect <name>` resolves the container's enclave domain and source repo, then runs a verified proxy locally — equivalent to `tinfoil proxy -e <domain> -r <repo>` but without copy-pasting either value.
+
+### Secrets, SSH keys, registry credentials, custom domains
+
+```bash
+# Org secrets (used by containers via --secret)
+tinfoil secret list
+echo -n "$OPENAI_KEY" | tinfoil secret create OPENAI_API_KEY --value-file -
+tinfoil secret set OPENAI_API_KEY --value-file ./key.txt
+tinfoil secret delete OPENAI_API_KEY
+
+# SSH keys for debug containers
+tinfoil ssh-key create laptop --public-key-file ~/.ssh/id_ed25519.pub
+tinfoil ssh-key list
+tinfoil ssh-key delete laptop
+
+# Private registry credentials
+tinfoil registry list
+tinfoil registry set ghcr --username myuser --token ghp_xxx
+tinfoil registry set gcr --key-file ./gcp-sa.json
+tinfoil registry set dockerhub --username myuser --token dckr_xxx
+tinfoil registry delete ghcr
+
+# Custom domains (TXT/CNAME instructions are printed on add/verify)
+tinfoil domain add api.example.com
+tinfoil domain verify api.example.com
+tinfoil domain delete api.example.com
+```
+
+Pass `-o json` on any list/get to emit machine-readable JSON.
 
 ## Proxy
 

--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+func init() {
+	rootCmd.AddCommand(loginCmd, logoutCmd, whoamiCmd)
+	for _, cmd := range []*cobra.Command{loginCmd, logoutCmd, whoamiCmd} {
+		cmd.SilenceUsage = true
+	}
+	loginCmd.Flags().String("url", "", "Controlplane URL (default https://api.tinfoil.sh)")
+	loginCmd.Flags().String("api-key", "", "Admin API key (admin_...). If omitted, prompts on stdin")
+}
+
+var loginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Log in to Tinfoil controlplane with an admin API key",
+	Long: `Store credentials for managing Tinfoil containers.
+
+Create an admin API key from the Tinfoil dashboard (Settings → API Keys → Admin keys).
+Admin keys are scoped to a single organization. The key is stored at
+~/.tinfoil/config.json (mode 0600). The TINFOIL_API_KEY and
+TINFOIL_CONTROLPLANE_URL environment variables override the saved values.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		urlFlag, _ := cmd.Flags().GetString("url")
+		keyFlag, _ := cmd.Flags().GetString("api-key")
+
+		cfg, _, err := loadConfig()
+		if err != nil {
+			return err
+		}
+
+		if urlFlag != "" {
+			cfg.ControlplaneURL = strings.TrimRight(urlFlag, "/")
+		}
+		if cfg.ControlplaneURL == "" {
+			cfg.ControlplaneURL = defaultControlplaneURL
+		}
+		if err := validateControlplaneURL(cfg.ControlplaneURL); err != nil {
+			return err
+		}
+
+		key := strings.TrimSpace(keyFlag)
+		if key == "" {
+			key, err = promptForAPIKey(cfg.ControlplaneURL)
+			if err != nil {
+				return err
+			}
+		}
+		if key == "" {
+			return errors.New("api key is required")
+		}
+		if !strings.HasPrefix(key, "admin_") {
+			return fmt.Errorf("expected an admin key (prefix admin_), got %q", redactKey(key))
+		}
+
+		cfg.APIKey = key
+
+		if err := verifyCredentials(cfg); err != nil {
+			return fmt.Errorf("credential check failed: %w", err)
+		}
+
+		path, err := saveConfig(cfg)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Logged in. Credentials saved to %s\n", path)
+		return nil
+	},
+}
+
+var logoutCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "Remove stored Tinfoil credentials",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path, removed, err := deleteConfig()
+		if err != nil {
+			return err
+		}
+		if !removed {
+			fmt.Printf("No credentials to remove (%s did not exist)\n", path)
+			return nil
+		}
+		fmt.Printf("Removed %s\n", path)
+		return nil
+	},
+}
+
+var whoamiCmd = &cobra.Command{
+	Use:   "whoami",
+	Short: "Show the current login and organization",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := requireAuth()
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Controlplane: %s\n", cfg.ControlplaneURL)
+		fmt.Printf("API key:      %s\n", redactKey(cfg.APIKey))
+
+		// Hit a cheap authenticated endpoint to confirm credentials and reveal
+		// the org-scoped host list (which fails 401 if the key is invalid).
+		client := newCPClient(cfg)
+		var hosts []hostInfo
+		if _, err := client.do("GET", "/api/containers/hosts", nil, nil, &hosts); err != nil {
+			return fmt.Errorf("verifying credentials: %w", err)
+		}
+		fmt.Printf("Status:       authenticated (%d host(s) available)\n", len(hosts))
+		return nil
+	},
+}
+
+func promptForAPIKey(controlplaneURL string) (string, error) {
+	fmt.Fprintf(os.Stderr, "Enter admin API key for %s: ", controlplaneURL)
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		raw, err := term.ReadPassword(int(os.Stdin.Fd()))
+		fmt.Fprintln(os.Stderr)
+		if err != nil {
+			return "", fmt.Errorf("reading api key: %w", err)
+		}
+		return strings.TrimSpace(string(raw)), nil
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 0, 4096), 1<<20)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return "", fmt.Errorf("reading api key: %w", err)
+		}
+		return "", errors.New("no api key provided")
+	}
+	return strings.TrimSpace(scanner.Text()), nil
+}
+
+func redactKey(key string) string {
+	if len(key) <= 12 {
+		return "***"
+	}
+	return key[:8] + "…" + key[len(key)-4:]
+}
+
+func verifyCredentials(cfg cliConfig) error {
+	client := newCPClient(cfg)
+	_, err := client.do("GET", "/api/containers/hosts", nil, nil, nil)
+	return err
+}

--- a/config.go
+++ b/config.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	defaultControlplaneURL = "https://api.tinfoil.sh"
+
+	envAPIKey      = "TINFOIL_API_KEY"
+	envCPURL       = "TINFOIL_CONTROLPLANE_URL"
+	envConfigPath  = "TINFOIL_CONFIG"
+)
+
+type cliConfig struct {
+	ControlplaneURL string `json:"controlplane_url"`
+	APIKey          string `json:"api_key"`
+}
+
+func configPath() (string, error) {
+	if p := os.Getenv(envConfigPath); p != "" {
+		return p, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("locating home directory: %w", err)
+	}
+	return filepath.Join(home, ".tinfoil", "config.json"), nil
+}
+
+func loadConfig() (cliConfig, string, error) {
+	path, err := configPath()
+	if err != nil {
+		return cliConfig{}, "", err
+	}
+
+	cfg := cliConfig{ControlplaneURL: defaultControlplaneURL}
+
+	// Reading the saved file is best-effort. A corrupt file (mid-write
+	// truncation, hand-editing typo) must not lock the user out — the env
+	// vars TINFOIL_API_KEY / TINFOIL_CONTROLPLANE_URL are documented as
+	// overrides, and `tinfoil login` itself goes through this path so a
+	// hard error here would also prevent rewriting the bad file.
+	if data, ferr := os.ReadFile(path); ferr == nil {
+		if jerr := json.Unmarshal(data, &cfg); jerr != nil {
+			fmt.Fprintf(os.Stderr, "warning: ignoring malformed %s (%v); falling back to defaults and env overrides\n", path, jerr)
+			cfg = cliConfig{ControlplaneURL: defaultControlplaneURL}
+		}
+	} else if !errors.Is(ferr, os.ErrNotExist) {
+		fmt.Fprintf(os.Stderr, "warning: cannot read %s (%v); falling back to defaults and env overrides\n", path, ferr)
+	}
+
+	if v := strings.TrimSpace(os.Getenv(envCPURL)); v != "" {
+		cfg.ControlplaneURL = v
+	}
+	if v := strings.TrimSpace(os.Getenv(envAPIKey)); v != "" {
+		cfg.APIKey = v
+	}
+
+	if cfg.ControlplaneURL == "" {
+		cfg.ControlplaneURL = defaultControlplaneURL
+	}
+	cfg.ControlplaneURL = strings.TrimRight(cfg.ControlplaneURL, "/")
+
+	return cfg, path, nil
+}
+
+func saveConfig(cfg cliConfig) (string, error) {
+	path, err := configPath()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return path, fmt.Errorf("creating %s: %w", filepath.Dir(path), err)
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return path, fmt.Errorf("encoding config: %w", err)
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, append(data, '\n'), 0o600); err != nil {
+		return path, fmt.Errorf("writing %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return path, fmt.Errorf("renaming to %s: %w", path, err)
+	}
+	return path, nil
+}
+
+func deleteConfig() (string, bool, error) {
+	path, err := configPath()
+	if err != nil {
+		return "", false, err
+	}
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return path, false, nil
+		}
+		return path, false, fmt.Errorf("removing %s: %w", path, err)
+	}
+	return path, true, nil
+}
+
+// requireAuth returns the loaded config or an error explaining how to
+// authenticate. Use it from commands that need to talk to the controlplane.
+func requireAuth() (cliConfig, error) {
+	cfg, _, err := loadConfig()
+	if err != nil {
+		return cliConfig{}, err
+	}
+	if cfg.APIKey == "" {
+		return cliConfig{}, fmt.Errorf("not logged in: run `tinfoil login` or set %s", envAPIKey)
+	}
+	if err := validateControlplaneURL(cfg.ControlplaneURL); err != nil {
+		return cliConfig{}, err
+	}
+	return cfg, nil
+}
+
+// validateControlplaneURL rejects URLs that would send the admin bearer
+// token over plaintext HTTP. Loopback hosts are allowed for local dev so
+// you can point the CLI at a controlplane running on localhost.
+func validateControlplaneURL(raw string) error {
+	if raw == "" {
+		return fmt.Errorf("controlplane URL is empty (set %s or run `tinfoil login --url ...`)", envCPURL)
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid controlplane URL %q: %w", raw, err)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("invalid controlplane URL %q: missing host (expected https://...)", raw)
+	}
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		host := u.Hostname()
+		if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+			return nil
+		}
+		return fmt.Errorf("controlplane URL %q must use https — refusing to send admin API key over plaintext (http is allowed only for localhost)", raw)
+	default:
+		return fmt.Errorf("controlplane URL %q must use https://", raw)
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadConfigMalformedFileFallsBackToEnv(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(cfgPath, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatalf("write malformed config: %v", err)
+	}
+
+	t.Setenv(envConfigPath, cfgPath)
+	t.Setenv(envCPURL, "https://staging.tinfoil.sh")
+	t.Setenv(envAPIKey, "admin_env_value")
+
+	cfg, gotPath, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig should succeed despite malformed file, got %v", err)
+	}
+	if gotPath != cfgPath {
+		t.Fatalf("path = %q, want %q", gotPath, cfgPath)
+	}
+	if cfg.APIKey != "admin_env_value" {
+		t.Fatalf("APIKey = %q, want env override to apply", cfg.APIKey)
+	}
+	if cfg.ControlplaneURL != "https://staging.tinfoil.sh" {
+		t.Fatalf("ControlplaneURL = %q, want env override to apply", cfg.ControlplaneURL)
+	}
+}
+
+func TestLoadConfigMissingFileUsesEnv(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "missing.json")
+
+	t.Setenv(envConfigPath, cfgPath)
+	t.Setenv(envCPURL, "https://staging.tinfoil.sh")
+	t.Setenv(envAPIKey, "admin_env_value")
+
+	cfg, _, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig should succeed for missing file, got %v", err)
+	}
+	if cfg.APIKey != "admin_env_value" {
+		t.Fatalf("APIKey = %q, want env override", cfg.APIKey)
+	}
+	if cfg.ControlplaneURL != "https://staging.tinfoil.sh" {
+		t.Fatalf("ControlplaneURL = %q, want env override", cfg.ControlplaneURL)
+	}
+}
+
+func TestLoadConfigValidFileStillParses(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(cfgPath, []byte(`{"controlplane_url":"https://saved.tinfoil.sh","api_key":"admin_saved"}`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	t.Setenv(envConfigPath, cfgPath)
+	t.Setenv(envCPURL, "")
+	t.Setenv(envAPIKey, "")
+
+	cfg, _, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.APIKey != "admin_saved" {
+		t.Fatalf("APIKey = %q, want admin_saved", cfg.APIKey)
+	}
+	if cfg.ControlplaneURL != "https://saved.tinfoil.sh" {
+		t.Fatalf("ControlplaneURL = %q, want saved value", cfg.ControlplaneURL)
+	}
+}
+
+func TestValidateControlplaneURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantError bool
+		errSubstr string
+	}{
+		{name: "https default", input: "https://api.tinfoil.sh"},
+		{name: "https with port and path", input: "https://api.tinfoil.sh:8443/cp"},
+		{name: "https subdomain", input: "https://staging.api.tinfoil.sh"},
+
+		{name: "http localhost", input: "http://localhost:8080"},
+		{name: "http 127.0.0.1", input: "http://127.0.0.1:8080"},
+		{name: "http ::1", input: "http://[::1]:8080"},
+
+		{name: "empty", input: "", wantError: true, errSubstr: "empty"},
+		{name: "no scheme", input: "api.tinfoil.sh", wantError: true, errSubstr: "missing host"},
+		{name: "http public", input: "http://api.tinfoil.sh", wantError: true, errSubstr: "must use https"},
+		{name: "http with userinfo", input: "http://user:pass@attacker.example.com", wantError: true, errSubstr: "must use https"},
+		{name: "ftp", input: "ftp://api.tinfoil.sh", wantError: true, errSubstr: "must use https"},
+		{name: "ws", input: "ws://api.tinfoil.sh", wantError: true, errSubstr: "must use https"},
+		{name: "https no host", input: "https://", wantError: true, errSubstr: "missing host"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateControlplaneURL(tt.input)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error for %q, got nil", tt.input)
+				}
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.input, err)
+			}
+		})
+	}
+}

--- a/container.go
+++ b/container.go
@@ -1,0 +1,942 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// containerView mirrors the controlplane's containerResponse. We only model
+// the fields the CLI actually displays or forwards; everything else stays in
+// RawMessage form so updates to the API don't break decoding here.
+type containerView struct {
+	ID                 string            `json:"id"`
+	Name               string            `json:"name"`
+	Repo               string            `json:"repo"`
+	Status             string            `json:"status"`
+	CurrentTag         string            `json:"current_tag"`
+	Domain             string            `json:"domain"`
+	InternalDomain     string            `json:"internal_domain"`
+	HostName           string            `json:"host_name"`
+	HostGpuType        string            `json:"host_gpu_type"`
+	HostCpuType        string            `json:"host_cpu_type"`
+	CPUs               int               `json:"cpus"`
+	GPUs               int               `json:"gpus"`
+	MemoryMB           int               `json:"memory_mb"`
+	Variables          json.RawMessage   `json:"variables"`
+	Secrets            []string          `json:"secrets"`
+	SSHKeys            []string          `json:"ssh_keys"`
+	Debug              bool              `json:"debug"`
+	Staging            bool              `json:"staging"`
+	GithubAppConnected bool              `json:"github_app_connected"`
+	AutoUpdate         bool              `json:"auto_update"`
+	GroupName          *string           `json:"group_name"`
+	GroupOrder         int               `json:"group_order"`
+	DisplayOrder       int               `json:"display_order"`
+	UpdateTag          string            `json:"update_tag"`
+	UpdateStatus       string            `json:"update_status"`
+	UpdateType         string            `json:"update_type"`
+	ErrorMessage       string            `json:"error_message"`
+	CreatedAt          string            `json:"created_at"`
+	UpdatedAt          string            `json:"updated_at"`
+	SSHPort            int               `json:"ssh_port"`
+}
+
+type hostInfo struct {
+	Name               string `json:"name"`
+	IsDefault          bool   `json:"is_default"`
+	AvailableGpuValues []int  `json:"available_gpu_values"`
+}
+
+var (
+	outputFormat string
+
+	createRepo         string
+	createTag          string
+	createDebug        bool
+	createStaging      bool
+	createCustomDomain string
+	createHost         string
+	createReplaceID    string
+	createVariables    []string
+	createSecrets      []string
+	createSSHKeys      []string
+
+	relaunchTag          string
+	relaunchVariables    []string
+	relaunchSecrets      []string
+	relaunchSSHKeys      []string
+	relaunchDebug        string
+	relaunchStaging      string
+	relaunchCustomDomain string
+	relaunchHost         string
+
+	startTag          string
+	startVariables    []string
+	startSecrets      []string
+	startSSHKeys      []string
+	startDebug        string
+	startStaging      string
+	startCustomDomain string
+	startHost         string
+
+	groupName         string
+	groupOrder        int32
+	groupDisplayOrder int32
+	groupUngroup      bool
+
+	autoUpdateOn  bool
+	autoUpdateOff bool
+
+	metricsTime string
+
+	connectPort     uint
+	connectBindAddr string
+
+	containerDebugSelector bool
+	useDebugFilter         bool
+)
+
+func init() {
+	rootCmd.AddCommand(containerCmd)
+	containerCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "Output format: table or json")
+
+	containerCmd.AddCommand(containerListCmd)
+	containerCmd.AddCommand(containerGetCmd)
+	containerCmd.AddCommand(containerCreateCmd)
+	containerCmd.AddCommand(containerDeleteCmd)
+	containerCmd.AddCommand(containerStartCmd)
+	containerCmd.AddCommand(containerStopCmd)
+	containerCmd.AddCommand(containerRelaunchCmd)
+	containerCmd.AddCommand(containerAutoUpdateCmd)
+	containerCmd.AddCommand(containerMetricsCmd)
+	containerCmd.AddCommand(containerHostsCmd)
+	containerCmd.AddCommand(containerGroupCmd)
+	containerCmd.AddCommand(containerUpdateCmd)
+	containerCmd.AddCommand(containerConnectCmd)
+
+	containerUpdateCmd.AddCommand(containerUpdateStatusCmd)
+	containerUpdateCmd.AddCommand(containerUpdateAcceptCmd)
+	containerUpdateCmd.AddCommand(containerUpdateCancelCmd)
+
+	containerCreateCmd.Flags().StringVar(&createRepo, "repo", "", "GitHub repo (owner/repo) holding tinfoil-config.yml [required]")
+	containerCreateCmd.Flags().StringVar(&createTag, "tag", "", "Repository release tag to deploy [required]")
+	containerCreateCmd.Flags().BoolVar(&createDebug, "debug", false, "Enable debug mode (allows SSH into the enclave)")
+	containerCreateCmd.Flags().BoolVar(&createStaging, "staging", false, "Use staging mode (lower-trust environment)")
+	containerCreateCmd.Flags().StringVar(&createCustomDomain, "custom-domain", "", "Verified custom domain to expose the container on")
+	containerCreateCmd.Flags().StringVar(&createHost, "host", "", "Target host name (see 'tinfoil container hosts')")
+	containerCreateCmd.Flags().StringVar(&createReplaceID, "replace", "", "ID of an existing container to atomically replace")
+	containerCreateCmd.Flags().StringArrayVar(&createVariables, "variable", nil, "Environment variable in KEY=VALUE form; may be repeated")
+	containerCreateCmd.Flags().StringArrayVar(&createSecrets, "secret", nil, "Org secret name to mount; may be repeated")
+	containerCreateCmd.Flags().StringArrayVar(&createSSHKeys, "ssh-key", nil, "Org SSH key name (debug only); may be repeated")
+	_ = containerCreateCmd.MarkFlagRequired("repo")
+	_ = containerCreateCmd.MarkFlagRequired("tag")
+
+	addDebugSelector(containerGetCmd)
+	addDebugSelector(containerDeleteCmd)
+	addDebugSelector(containerStartCmd)
+	addDebugSelector(containerStopCmd)
+	addDebugSelector(containerRelaunchCmd)
+	addDebugSelector(containerAutoUpdateCmd)
+	addDebugSelector(containerMetricsCmd)
+	addDebugSelector(containerGroupCmd)
+	addDebugSelector(containerUpdateStatusCmd)
+	addDebugSelector(containerUpdateAcceptCmd)
+	addDebugSelector(containerUpdateCancelCmd)
+	addDebugSelector(containerConnectCmd)
+
+	containerStartCmd.Flags().StringVar(&startTag, "tag", "", "Override the deployed tag")
+	containerStartCmd.Flags().StringArrayVar(&startVariables, "variable", nil, "Override environment variable in KEY=VALUE form")
+	containerStartCmd.Flags().StringArrayVar(&startSecrets, "secret", nil, "Override secrets list (specify all)")
+	containerStartCmd.Flags().StringArrayVar(&startSSHKeys, "ssh-key", nil, "Override SSH keys list")
+	containerStartCmd.Flags().StringVar(&startDebug, "debug", "", "Override debug mode (true/false)")
+	containerStartCmd.Flags().StringVar(&startStaging, "staging", "", "Override staging mode (true/false)")
+	containerStartCmd.Flags().StringVar(&startCustomDomain, "custom-domain", "", "Override custom domain (empty string clears it)")
+	containerStartCmd.Flags().StringVar(&startHost, "host", "", "Move stopped container to a different host")
+
+	containerRelaunchCmd.Flags().StringVar(&relaunchTag, "tag", "", "Override the deployed tag")
+	containerRelaunchCmd.Flags().StringArrayVar(&relaunchVariables, "variable", nil, "Override environment variable in KEY=VALUE form")
+	containerRelaunchCmd.Flags().StringArrayVar(&relaunchSecrets, "secret", nil, "Override secrets list (specify all)")
+	containerRelaunchCmd.Flags().StringArrayVar(&relaunchSSHKeys, "ssh-key", nil, "Override SSH keys list")
+	containerRelaunchCmd.Flags().StringVar(&relaunchDebug, "debug", "", "Override debug mode (true/false)")
+	containerRelaunchCmd.Flags().StringVar(&relaunchStaging, "staging", "", "Override staging mode (true/false)")
+	containerRelaunchCmd.Flags().StringVar(&relaunchCustomDomain, "custom-domain", "", "Override custom domain (empty string clears it)")
+	containerRelaunchCmd.Flags().StringVar(&relaunchHost, "host", "", "Move failed container to a different host")
+
+	containerAutoUpdateCmd.Flags().BoolVar(&autoUpdateOn, "on", false, "Enable auto-update")
+	containerAutoUpdateCmd.Flags().BoolVar(&autoUpdateOff, "off", false, "Disable auto-update")
+
+	containerMetricsCmd.Flags().StringVar(&metricsTime, "time", "24h", "Time window (e.g. 1h, 24h, 7d)")
+
+	containerGroupCmd.Flags().StringVar(&groupName, "name", "", "Group name to assign")
+	containerGroupCmd.Flags().BoolVar(&groupUngroup, "ungroup", false, "Remove the container from any group")
+	containerGroupCmd.Flags().Int32Var(&groupOrder, "group-order", 0, "Order of the group itself")
+	containerGroupCmd.Flags().Int32Var(&groupDisplayOrder, "display-order", 0, "Display order within the group")
+
+	containerConnectCmd.Flags().UintVarP(&connectPort, "port", "p", 8080, "Local port for the verified proxy")
+	containerConnectCmd.Flags().StringVarP(&connectBindAddr, "bind", "b", "127.0.0.1", "Address to bind to")
+
+	silenceUsageRecursive(containerCmd)
+}
+
+// silenceUsageRecursive walks the command tree and sets SilenceUsage so that
+// runtime errors (auth, network, validation) don't dump the help banner.
+func silenceUsageRecursive(cmd *cobra.Command) {
+	cmd.SilenceUsage = true
+	for _, c := range cmd.Commands() {
+		silenceUsageRecursive(c)
+	}
+}
+
+func addDebugSelector(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&containerDebugSelector, "debug-mode", false, "Match containers in debug mode when resolving by name")
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		useDebugFilter = cmd.Flags().Changed("debug-mode")
+		return nil
+	}
+}
+
+var containerCmd = &cobra.Command{
+	Use:          "container",
+	Aliases:      []string{"containers", "ct"},
+	Short:        "Manage Tinfoil containers",
+	SilenceUsage: true,
+}
+
+var containerListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List containers in the current organization",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		var list []containerView
+		if _, err := client.do("GET", "/api/containers", nil, nil, &list); err != nil {
+			return err
+		}
+		return renderContainers(list)
+	},
+}
+
+var containerGetCmd = &cobra.Command{
+	Use:   "get [id|name]",
+	Short: "Show a single container",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		c, err := resolveContainer(client, args[0])
+		if err != nil {
+			return err
+		}
+		return renderContainer(*c)
+	},
+}
+
+var containerCreateCmd = &cobra.Command{
+	Use:   "create [name]",
+	Short: "Create a new container",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+
+		vars, err := parseKeyValues(createVariables)
+		if err != nil {
+			return err
+		}
+
+		body := map[string]any{
+			"name": args[0],
+			"repo": createRepo,
+			"tag":  createTag,
+		}
+		if len(vars) > 0 {
+			body["variables"] = vars
+		}
+		if len(createSecrets) > 0 {
+			body["secrets"] = createSecrets
+		}
+		if len(createSSHKeys) > 0 {
+			body["ssh_keys"] = createSSHKeys
+		}
+		if createDebug {
+			body["debug"] = true
+		}
+		if createStaging {
+			body["staging"] = true
+		}
+		if createCustomDomain != "" {
+			body["custom_domain"] = createCustomDomain
+		}
+		if createHost != "" {
+			body["host_name"] = createHost
+		}
+		if createReplaceID != "" {
+			body["replace_container_id"] = createReplaceID
+		}
+
+		var created containerView
+		if _, err := client.do("POST", "/api/containers", nil, body, &created); err != nil {
+			return err
+		}
+		return renderContainer(created)
+	},
+}
+
+var containerDeleteCmd = &cobra.Command{
+	Use:     "delete [id|name]",
+	Aliases: []string{"rm", "remove"},
+	Short:   "Delete a container",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		c, err := resolveContainer(client, args[0])
+		if err != nil {
+			return err
+		}
+		if _, err := client.do("DELETE", pathf("/api/containers/%s", c.ID), nil, nil, nil); err != nil {
+			return err
+		}
+		fmt.Printf("Deleted container %s (%s)\n", c.Name, c.ID)
+		return nil
+	},
+}
+
+var containerStartCmd = &cobra.Command{
+	Use:   "start [id|name]",
+	Short: "Start a stopped container",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		c, err := resolveContainer(client, args[0])
+		if err != nil {
+			return err
+		}
+		body, err := buildLifecycleBody(cmd,
+			startTag, startVariables, startSecrets, startSSHKeys,
+			startDebug, startStaging, startCustomDomain, startHost,
+		)
+		if err != nil {
+			return err
+		}
+		var updated containerView
+		if _, err := client.do("POST", pathf("/api/containers/%s/start", c.ID), nil, body, &updated); err != nil {
+			return err
+		}
+		return renderContainer(updated)
+	},
+}
+
+var containerStopCmd = &cobra.Command{
+	Use:   "stop [id|name]",
+	Short: "Stop a running container",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		c, err := resolveContainer(client, args[0])
+		if err != nil {
+			return err
+		}
+		var updated containerView
+		if _, err := client.do("POST", pathf("/api/containers/%s/stop", c.ID), nil, nil, &updated); err != nil {
+			return err
+		}
+		return renderContainer(updated)
+	},
+}
+
+var containerRelaunchCmd = &cobra.Command{
+	Use:   "relaunch [id|name]",
+	Short: "Redeploy a running or failed container",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		c, err := resolveContainer(client, args[0])
+		if err != nil {
+			return err
+		}
+		body, err := buildLifecycleBody(cmd,
+			relaunchTag, relaunchVariables, relaunchSecrets, relaunchSSHKeys,
+			relaunchDebug, relaunchStaging, relaunchCustomDomain, relaunchHost,
+		)
+		if err != nil {
+			return err
+		}
+		// /relaunch requires a body even when empty so the controlplane decoder
+		// can read fields it doesn't necessarily set.
+		if body == nil {
+			body = map[string]any{}
+		}
+		var updated containerView
+		if _, err := client.do("POST", pathf("/api/containers/%s/relaunch", c.ID), nil, body, &updated); err != nil {
+			return err
+		}
+		return renderContainer(updated)
+	},
+}
+
+var containerAutoUpdateCmd = &cobra.Command{
+	Use:   "auto-update [id|name]",
+	Short: "Toggle auto-update for a GitHub-connected container",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if autoUpdateOn == autoUpdateOff {
+			return fmt.Errorf("specify exactly one of --on or --off")
+		}
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		c, err := resolveContainer(client, args[0])
+		if err != nil {
+			return err
+		}
+		body := map[string]any{"auto_update": autoUpdateOn}
+		var updated containerView
+		if _, err := client.do("POST", pathf("/api/containers/%s/auto-update", c.ID), nil, body, &updated); err != nil {
+			return err
+		}
+		fmt.Printf("auto_update=%v on %s\n", updated.AutoUpdate, updated.Name)
+		return nil
+	},
+}
+
+var containerMetricsCmd = &cobra.Command{
+	Use:   "metrics [id|name]",
+	Short: "Show container resource metrics",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		c, err := resolveContainer(client, args[0])
+		if err != nil {
+			return err
+		}
+		q := url.Values{"time": []string{metricsTime}}
+		var raw json.RawMessage
+		if _, err := client.do("GET", pathf("/api/containers/%s/metrics", c.ID), q, nil, &raw); err != nil {
+			return err
+		}
+		// Metrics are time-series data; printing JSON is the most useful
+		// default. Users who want a chart can pipe into jq.
+		os.Stdout.Write(prettyJSON(raw))
+		fmt.Println()
+		return nil
+	},
+}
+
+var containerHostsCmd = &cobra.Command{
+	Use:   "hosts",
+	Short: "List container hosts available to your organization",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		var hosts []hostInfo
+		if _, err := client.do("GET", "/api/containers/hosts", nil, nil, &hosts); err != nil {
+			return err
+		}
+		if outputFormat == "json" {
+			return printJSON(hosts)
+		}
+		if len(hosts) == 0 {
+			fmt.Println("No container hosts available.")
+			return nil
+		}
+		fmt.Printf("%-24s  %-10s  %s\n", "NAME", "DEFAULT", "GPU SIZES")
+		for _, h := range hosts {
+			fmt.Printf("%-24s  %-10v  %s\n", h.Name, h.IsDefault, formatInts(h.AvailableGpuValues))
+		}
+		return nil
+	},
+}
+
+var containerGroupCmd = &cobra.Command{
+	Use:   "group [id|name]",
+	Short: "Move a container into (or out of) a group",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !groupUngroup && groupName == "" {
+			return fmt.Errorf("specify --name <group> or --ungroup")
+		}
+		if groupUngroup && groupName != "" {
+			return fmt.Errorf("--name and --ungroup are mutually exclusive")
+		}
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		c, err := resolveContainer(client, args[0])
+		if err != nil {
+			return err
+		}
+		// The controlplane has no partial-update semantics for these fields;
+		// any value sent (including 0) is written verbatim. Preserve the
+		// container's current order when the user didn't pass the flag, so
+		// `container group my-app --name foo` doesn't silently reset
+		// existing positions.
+		groupOrderToSend := int32(c.GroupOrder)
+		if cmd.Flags().Changed("group-order") {
+			groupOrderToSend = groupOrder
+		}
+		displayOrderToSend := int32(c.DisplayOrder)
+		if cmd.Flags().Changed("display-order") {
+			displayOrderToSend = groupDisplayOrder
+		}
+		body := map[string]any{
+			"group_order":   groupOrderToSend,
+			"display_order": displayOrderToSend,
+		}
+		if groupUngroup {
+			body["group_name"] = nil
+		} else {
+			body["group_name"] = groupName
+		}
+		var updated containerView
+		if _, err := client.do("PUT", pathf("/api/containers/%s/group", c.ID), nil, body, &updated); err != nil {
+			return err
+		}
+		return renderContainer(updated)
+	},
+}
+
+var containerUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Manage in-progress container updates",
+}
+
+var containerUpdateStatusCmd = &cobra.Command{
+	Use:   "status [id|name]",
+	Short: "Show the status of an in-progress update",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		c, err := resolveContainer(client, args[0])
+		if err != nil {
+			return err
+		}
+		var raw json.RawMessage
+		if _, err := client.do("GET", pathf("/api/containers/%s/update", c.ID), nil, nil, &raw); err != nil {
+			return err
+		}
+		os.Stdout.Write(prettyJSON(raw))
+		fmt.Println()
+		return nil
+	},
+}
+
+var containerUpdateAcceptCmd = &cobra.Command{
+	Use:   "accept [id|name]",
+	Short: "Promote a ready staged update",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		c, err := resolveContainer(client, args[0])
+		if err != nil {
+			return err
+		}
+		var updated containerView
+		if _, err := client.do("POST", pathf("/api/containers/%s/update/accept", c.ID), nil, nil, &updated); err != nil {
+			return err
+		}
+		return renderContainer(updated)
+	},
+}
+
+var containerUpdateCancelCmd = &cobra.Command{
+	Use:   "cancel [id|name]",
+	Short: "Cancel an in-progress update",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		c, err := resolveContainer(client, args[0])
+		if err != nil {
+			return err
+		}
+		if _, err := client.do("POST", pathf("/api/containers/%s/update/cancel", c.ID), nil, nil, nil); err != nil {
+			return err
+		}
+		fmt.Printf("Cancelled in-progress update on %s\n", c.Name)
+		return nil
+	},
+}
+
+var containerConnectCmd = &cobra.Command{
+	Use:   "connect [id|name]",
+	Short: "Run a verified proxy to a deployed container",
+	Long: `Resolve a deployed container by name (or ID), look up its enclave domain
+and source repository, then start a local proxy that verifies the enclave's
+attestation and forwards HTTP requests to it. This is a convenience around
+` + "`tinfoil proxy -e <domain> -r <repo>`" + `.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		c, err := resolveContainer(client, args[0])
+		if err != nil {
+			return err
+		}
+		host := strings.TrimSpace(c.Domain)
+		if host == "" {
+			host = strings.TrimSpace(c.InternalDomain)
+		}
+		if host == "" {
+			return fmt.Errorf("container %s has no domain (status=%s) — cannot connect", c.Name, c.Status)
+		}
+		if c.Repo == "" {
+			return fmt.Errorf("container %s has no repo recorded — cannot connect", c.Name)
+		}
+		fmt.Printf("Connecting verified proxy to %s (%s) for repo %s\n", c.Name, host, c.Repo)
+
+		enclaveHost = host
+		repo = c.Repo
+		listenAddr = connectBindAddr
+		listenPort = connectPort
+		return proxyCmd.RunE(proxyCmd, nil)
+	},
+}
+
+func authedClient() (*cpClient, error) {
+	cfg, err := requireAuth()
+	if err != nil {
+		return nil, err
+	}
+	return newCPClient(cfg), nil
+}
+
+// resolveContainer accepts either a UUID or a name. When given a name,
+// list containers and pick the one with a matching name. If both a debug
+// and a non-debug container share the name, --debug-mode disambiguates.
+func resolveContainer(client *cpClient, identifier string) (*containerView, error) {
+	id := strings.TrimSpace(identifier)
+	if id == "" {
+		return nil, fmt.Errorf("container identifier is empty")
+	}
+	if looksLikeUUID(id) {
+		var c containerView
+		if _, err := client.do("GET", pathf("/api/containers/%s", id), nil, nil, &c); err != nil {
+			return nil, err
+		}
+		return &c, nil
+	}
+
+	var list []containerView
+	if _, err := client.do("GET", "/api/containers", nil, nil, &list); err != nil {
+		return nil, err
+	}
+	matches := make([]containerView, 0, 2)
+	for _, c := range list {
+		if c.Name != id {
+			continue
+		}
+		if useDebugFilter && c.Debug != containerDebugSelector {
+			continue
+		}
+		matches = append(matches, c)
+	}
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("no container named %q (use the container ID or `tinfoil container list`)", id)
+	case 1:
+		c := matches[0]
+		return &c, nil
+	default:
+		return nil, fmt.Errorf("multiple containers named %q (debug + non-debug); pass --debug-mode or use the container ID", id)
+	}
+}
+
+func looksLikeUUID(s string) bool {
+	// 8-4-4-4-12 hex; cheap check that avoids importing google/uuid.
+	if len(s) != 36 {
+		return false
+	}
+	for i, ch := range s {
+		switch i {
+		case 8, 13, 18, 23:
+			if ch != '-' {
+				return false
+			}
+		default:
+			if !((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func parseKeyValues(in []string) (map[string]string, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(in))
+	for _, raw := range in {
+		k, v, ok := strings.Cut(raw, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid variable %q: expected KEY=VALUE", raw)
+		}
+		k = strings.TrimSpace(k)
+		if k == "" {
+			return nil, fmt.Errorf("invalid variable %q: empty key", raw)
+		}
+		out[k] = v
+	}
+	return out, nil
+}
+
+// buildLifecycleBody assembles the request body shared by /start and
+// /relaunch. Only fields whose flag was set on the command line are included
+// so the controlplane keeps the existing values for the rest.
+func buildLifecycleBody(cmd *cobra.Command,
+	tag string,
+	variables, secrets, sshKeys []string,
+	debug, staging, customDomain, host string,
+) (map[string]any, error) {
+	body := map[string]any{}
+	if cmd.Flags().Changed("tag") && tag != "" {
+		body["tag"] = tag
+	}
+	if cmd.Flags().Changed("variable") {
+		vars, err := parseKeyValues(variables)
+		if err != nil {
+			return nil, err
+		}
+		if vars == nil {
+			vars = map[string]string{}
+		}
+		body["variables"] = vars
+	}
+	if cmd.Flags().Changed("secret") {
+		if secrets == nil {
+			secrets = []string{}
+		}
+		body["secrets"] = secrets
+	}
+	if cmd.Flags().Changed("ssh-key") {
+		if sshKeys == nil {
+			sshKeys = []string{}
+		}
+		body["ssh_keys"] = sshKeys
+	}
+	if cmd.Flags().Changed("debug") {
+		v, err := parseTriBool(debug)
+		if err != nil {
+			return nil, fmt.Errorf("--debug: %w", err)
+		}
+		body["debug"] = v
+	}
+	if cmd.Flags().Changed("staging") {
+		v, err := parseTriBool(staging)
+		if err != nil {
+			return nil, fmt.Errorf("--staging: %w", err)
+		}
+		body["staging"] = v
+	}
+	if cmd.Flags().Changed("custom-domain") {
+		body["custom_domain"] = customDomain
+	}
+	if cmd.Flags().Changed("host") {
+		body["host_name"] = host
+	}
+	if len(body) == 0 {
+		return nil, nil
+	}
+	return body, nil
+}
+
+func parseTriBool(s string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "true", "t", "yes", "y", "1", "on":
+		return true, nil
+	case "false", "f", "no", "n", "0", "off":
+		return false, nil
+	default:
+		return false, fmt.Errorf("expected true/false, got %q", s)
+	}
+}
+
+func formatInts(in []int) string {
+	if len(in) == 0 {
+		return "-"
+	}
+	out := make([]string, len(in))
+	for i, v := range in {
+		out[i] = fmt.Sprintf("%d", v)
+	}
+	return strings.Join(out, ",")
+}
+
+func renderContainer(c containerView) error {
+	if outputFormat == "json" {
+		return printJSON(c)
+	}
+	fmt.Printf("ID:           %s\n", c.ID)
+	fmt.Printf("Name:         %s\n", c.Name)
+	fmt.Printf("Status:       %s\n", c.Status)
+	fmt.Printf("Repo:         %s@%s\n", c.Repo, c.CurrentTag)
+	if c.Domain != "" {
+		fmt.Printf("Domain:       %s\n", c.Domain)
+	}
+	if c.InternalDomain != "" && c.InternalDomain != c.Domain {
+		fmt.Printf("Internal:     %s\n", c.InternalDomain)
+	}
+	if c.HostName != "" {
+		fmt.Printf("Host:         %s (cpu=%s gpu=%s)\n", c.HostName, c.HostCpuType, c.HostGpuType)
+	}
+	fmt.Printf("Resources:    cpus=%d gpus=%d mem=%dMB\n", c.CPUs, c.GPUs, c.MemoryMB)
+	if c.Debug {
+		fmt.Printf("Mode:         debug\n")
+	}
+	if c.Staging {
+		fmt.Printf("Mode:         staging\n")
+	}
+	if c.AutoUpdate {
+		fmt.Printf("Auto-update:  enabled\n")
+	}
+	if c.SSHPort > 0 {
+		fmt.Printf("SSH port:     %d\n", c.SSHPort)
+	}
+	if vars, _ := decodeContainerVariables(c.Variables); len(vars) > 0 {
+		keys := make([]string, 0, len(vars))
+		for k := range vars {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		fmt.Printf("Variables:    %s\n", strings.Join(keys, ", "))
+	}
+	if len(c.Secrets) > 0 {
+		fmt.Printf("Secrets:      %s\n", strings.Join(c.Secrets, ", "))
+	}
+	if len(c.SSHKeys) > 0 {
+		fmt.Printf("SSH keys:     %s\n", strings.Join(c.SSHKeys, ", "))
+	}
+	if c.UpdateTag != "" {
+		state := c.UpdateStatus
+		if c.UpdateType != "" {
+			state = state + "/" + c.UpdateType
+		}
+		fmt.Printf("In-progress:  %s (%s)\n", c.UpdateTag, state)
+	}
+	if c.ErrorMessage != "" {
+		fmt.Printf("Error:        %s\n", c.ErrorMessage)
+	}
+	return nil
+}
+
+func renderContainers(list []containerView) error {
+	if outputFormat == "json" {
+		return printJSON(list)
+	}
+	if len(list) == 0 {
+		fmt.Println("No containers.")
+		return nil
+	}
+	fmt.Printf("%-24s  %-10s  %-30s  %-10s  %s\n", "NAME", "STATUS", "DOMAIN", "TAG", "REPO")
+	for _, c := range list {
+		domain := c.Domain
+		if domain == "" {
+			domain = "-"
+		}
+		tag := c.CurrentTag
+		if tag == "" {
+			tag = "-"
+		}
+		fmt.Printf("%-24s  %-10s  %-30s  %-10s  %s\n",
+			truncate(c.Name, 24), c.Status, truncate(domain, 30), truncate(tag, 10), c.Repo,
+		)
+	}
+	return nil
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	if max <= 1 {
+		return "…"
+	}
+	return s[:max-1] + "…"
+}
+
+func printJSON(v any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// decodeContainerVariables handles both the JSON-object form and the
+// base64-encoded JSONB form returned by the controlplane (the database column
+// is `[]byte`, which encoding/json renders as a base64 string).
+func decodeContainerVariables(raw json.RawMessage) (map[string]string, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	out := make(map[string]string)
+	if err := json.Unmarshal(raw, &out); err == nil {
+		return out, nil
+	}
+	var encoded string
+	if err := json.Unmarshal(raw, &encoded); err != nil {
+		return nil, err
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(decoded, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func prettyJSON(raw json.RawMessage) []byte {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return raw
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return raw
+	}
+	return out
+}
+

--- a/controlplane.go
+++ b/controlplane.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type cpClient struct {
+	baseURL string
+	apiKey  string
+	http    *http.Client
+}
+
+func newCPClient(cfg cliConfig) *cpClient {
+	return &cpClient{
+		baseURL: strings.TrimRight(cfg.ControlplaneURL, "/"),
+		apiKey:  cfg.APIKey,
+		http:    &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+// cpError carries a structured error from the controlplane.
+type cpError struct {
+	Status  int
+	Method  string
+	Path    string
+	Message string
+	Body    []byte
+}
+
+func (e *cpError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("%s %s: %d: %s", e.Method, e.Path, e.Status, e.Message)
+	}
+	return fmt.Sprintf("%s %s: %d", e.Method, e.Path, e.Status)
+}
+
+// do performs an authenticated request against the controlplane. body may be
+// nil. out may be nil to discard the response body. Returns the parsed status
+// code on success, or a *cpError on non-2xx responses.
+func (c *cpClient) do(method, path string, query url.Values, body any, out any) (int, error) {
+	if err := validateControlplaneURL(c.baseURL); err != nil {
+		return 0, err
+	}
+	u := c.baseURL + path
+	if query != nil {
+		u += "?" + query.Encode()
+	}
+
+	var reader io.Reader
+	if body != nil {
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return 0, fmt.Errorf("encoding request body: %w", err)
+		}
+		reader = bytes.NewReader(buf)
+	}
+
+	req, err := http.NewRequest(method, u, reader)
+	if err != nil {
+		return 0, fmt.Errorf("building request: %w", err)
+	}
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("controlplane request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return resp.StatusCode, &cpError{
+			Status:  resp.StatusCode,
+			Method:  method,
+			Path:    path,
+			Message: extractErrorMessage(respBody),
+			Body:    respBody,
+		}
+	}
+
+	if out != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return resp.StatusCode, fmt.Errorf("decoding response: %w", err)
+		}
+	}
+	return resp.StatusCode, nil
+}
+
+// pathf builds a controlplane URL path by url.PathEscape-ing each segment
+// before substituting it into the printf-style format. Use this anywhere a
+// path component comes from user input or unverified server data — string
+// concatenation would let `..` or `/` in a name traverse to a different
+// endpoint than the one the command names.
+func pathf(format string, segments ...string) string {
+	args := make([]any, len(segments))
+	for i, s := range segments {
+		args[i] = url.PathEscape(s)
+	}
+	return fmt.Sprintf(format, args...)
+}
+
+// extractErrorMessage best-effort decodes controlplane error payloads which
+// usually look like {"error":"..."} or {"message":"..."}.
+func extractErrorMessage(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err == nil {
+		for _, key := range []string{"error", "message"} {
+			if v, ok := m[key].(string); ok && v != "" {
+				return v
+			}
+		}
+	}
+	s := strings.TrimSpace(string(body))
+	if len(s) > 240 {
+		s = s[:240] + "…"
+	}
+	return s
+}

--- a/controlplane_test.go
+++ b/controlplane_test.go
@@ -1,0 +1,75 @@
+package main
+
+import "testing"
+
+func TestPathfEscapesSegments(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		segs   []string
+		want   string
+	}{
+		{
+			name:   "plain segment",
+			format: "/api/secrets/%s",
+			segs:   []string{"DATABASE_URL"},
+			want:   "/api/secrets/DATABASE_URL",
+		},
+		{
+			name:   "hyphenated kebab name",
+			format: "/api/ssh-keys/%s",
+			segs:   []string{"my-deploy-key"},
+			want:   "/api/ssh-keys/my-deploy-key",
+		},
+		{
+			name:   "uuid is unchanged",
+			format: "/api/containers/%s/start",
+			segs:   []string{"61bd4a3e-5b48-4320-9215-0c7a7f974979"},
+			want:   "/api/containers/61bd4a3e-5b48-4320-9215-0c7a7f974979/start",
+		},
+		{
+			name:   "slash in name does not split segment",
+			format: "/api/secrets/%s",
+			segs:   []string{"foo/bar"},
+			want:   "/api/secrets/foo%2Fbar",
+		},
+		{
+			name:   "traversal cannot reach a sibling endpoint",
+			format: "/api/ssh-keys/%s",
+			segs:   []string{"../secrets/X"},
+			want:   "/api/ssh-keys/..%2Fsecrets%2FX",
+		},
+		{
+			name:   "query separator stays in segment",
+			format: "/api/secrets/%s",
+			segs:   []string{"foo?delete=true"},
+			want:   "/api/secrets/foo%3Fdelete=true",
+		},
+		{
+			name:   "fragment separator stays in segment",
+			format: "/api/secrets/%s",
+			segs:   []string{"foo#bar"},
+			want:   "/api/secrets/foo%23bar",
+		},
+		{
+			name:   "space encoded",
+			format: "/api/secrets/%s",
+			segs:   []string{"foo bar"},
+			want:   "/api/secrets/foo%20bar",
+		},
+		{
+			name:   "multiple segments",
+			format: "/api/orgs/%s/keys/%s",
+			segs:   []string{"acme/admin", "k1"},
+			want:   "/api/orgs/acme%2Fadmin/keys/k1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pathf(tt.format, tt.segs...)
+			if got != tt.want {
+				t.Fatalf("pathf(%q, %v) = %q, want %q", tt.format, tt.segs, got, tt.want)
+			}
+		})
+	}
+}

--- a/domain.go
+++ b/domain.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type domainView struct {
+	ID                string   `json:"id"`
+	Domain            string   `json:"domain"`
+	VerificationNonce string   `json:"verification_nonce"`
+	CnameHash         string   `json:"cname_hash"`
+	Verified          bool     `json:"verified"`
+	VerifiedAt        *string  `json:"verified_at"`
+	CreatedAt         string   `json:"created_at"`
+	UsedBy            []string `json:"used_by"`
+	TXTRecordHost     string   `json:"txt_record_host"`
+	TXTRecordValue    string   `json:"txt_record_value"`
+	CNAMETarget       string   `json:"cname_target"`
+	CNAMEConfigured   *bool    `json:"cname_configured"`
+}
+
+func init() {
+	rootCmd.AddCommand(domainCmd)
+	domainCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "Output format: table or json")
+	domainCmd.AddCommand(domainListCmd, domainAddCmd, domainVerifyCmd, domainDeleteCmd)
+	silenceUsageRecursive(domainCmd)
+}
+
+var domainCmd = &cobra.Command{
+	Use:          "domain",
+	Aliases:      []string{"domains"},
+	Short:        "Manage custom domains for containers",
+	SilenceUsage: true,
+}
+
+var domainListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List custom domains",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		var list []domainView
+		if _, err := client.do("GET", "/api/domains", nil, nil, &list); err != nil {
+			return err
+		}
+		if outputFormat == "json" {
+			return printJSON(list)
+		}
+		if len(list) == 0 {
+			fmt.Println("No custom domains.")
+			return nil
+		}
+		fmt.Printf("%-40s  %-10s  %-30s  %s\n", "DOMAIN", "VERIFIED", "CNAME TARGET", "USED BY")
+		for _, d := range list {
+			used := strings.Join(d.UsedBy, ", ")
+			if used == "" {
+				used = "-"
+			}
+			fmt.Printf("%-40s  %-10v  %-30s  %s\n",
+				truncate(d.Domain, 40), d.Verified, truncate(d.CNAMETarget, 30), used,
+			)
+		}
+		return nil
+	},
+}
+
+var domainAddCmd = &cobra.Command{
+	Use:   "add [domain]",
+	Short: "Register a new custom domain (returns DNS records to configure)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		body := map[string]any{"domain": args[0]}
+		var d domainView
+		if _, err := client.do("POST", "/api/domains", nil, body, &d); err != nil {
+			return err
+		}
+		return renderDomain(d, false)
+	},
+}
+
+var domainVerifyCmd = &cobra.Command{
+	Use:   "verify [domain]",
+	Short: "Re-check the DNS TXT record and update verification status",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		var d domainView
+		if _, err := client.do("POST", pathf("/api/domains/%s/verify", args[0]), nil, nil, &d); err != nil {
+			return err
+		}
+		return renderDomain(d, true)
+	},
+}
+
+var domainDeleteCmd = &cobra.Command{
+	Use:     "delete [domain]",
+	Aliases: []string{"rm", "remove"},
+	Short:   "Delete a custom domain (fails if any container uses it)",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		if _, err := client.do("DELETE", pathf("/api/domains/%s", args[0]), nil, nil, nil); err != nil {
+			return err
+		}
+		fmt.Printf("Deleted domain %s\n", args[0])
+		return nil
+	},
+}
+
+func renderDomain(d domainView, verifyMode bool) error {
+	if outputFormat == "json" {
+		return printJSON(d)
+	}
+	fmt.Printf("Domain:     %s\n", d.Domain)
+	fmt.Printf("Verified:   %v\n", d.Verified)
+	if d.VerifiedAt != nil {
+		fmt.Printf("Verified at: %s\n", *d.VerifiedAt)
+	}
+	fmt.Printf("\nConfigure these DNS records on your domain:\n")
+	fmt.Printf("  TXT  %s  =>  %s\n", d.TXTRecordHost, d.TXTRecordValue)
+	fmt.Printf("  CNAME  %s  =>  %s\n", d.Domain, d.CNAMETarget)
+	if verifyMode && d.CNAMEConfigured != nil {
+		fmt.Printf("\nCNAME currently observed: %v\n", *d.CNAMEConfigured)
+	}
+	if !d.Verified {
+		fmt.Printf("\nRun `tinfoil domain verify %s` after the TXT record propagates.\n", d.Domain)
+	}
+	if len(d.UsedBy) > 0 {
+		fmt.Printf("\nUsed by: %s\n", strings.Join(d.UsedBy, ", "))
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/tinfoilsh/tinfoil-go v0.12.4
+	golang.org/x/term v0.39.0
 )
 
 require (
@@ -90,7 +91,6 @@ require (
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
-	golang.org/x/term v0.39.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	google.golang.org/genproto v0.0.0-20260120221211-b8f7ae30c516 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260203192932-546029d2fa20 // indirect

--- a/registry.go
+++ b/registry.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// matches services.RegistryGHCR / RegistryGCR / RegistryDockerHub on the
+// controlplane side.
+const (
+	registryGHCR      = "ghcr"
+	registryGCR       = "gcr"
+	registryDockerHub = "dockerhub"
+)
+
+type registryStatus struct {
+	HasCredentials bool   `json:"has_credentials"`
+	Username       string `json:"username,omitempty"`
+	UpdatedAt      string `json:"updated_at,omitempty"`
+	Expired        bool   `json:"expired"`
+}
+
+type registryListResponse struct {
+	GHCR      registryStatus `json:"ghcr"`
+	GCR       registryStatus `json:"gcr"`
+	DockerHub registryStatus `json:"dockerhub"`
+}
+
+var (
+	registryUsername string
+	registryToken    string
+	registryKeyFile  string
+)
+
+func init() {
+	rootCmd.AddCommand(registryCmd)
+	registryCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "Output format: table or json")
+	registryCmd.AddCommand(registryListCmd, registrySetCmd, registryDeleteCmd)
+
+	registrySetCmd.Flags().StringVar(&registryUsername, "username", "", "Registry username (ghcr, dockerhub)")
+	registrySetCmd.Flags().StringVar(&registryToken, "token", "", "Registry token / password (ghcr, dockerhub)")
+	registrySetCmd.Flags().StringVar(&registryKeyFile, "key-file", "", "Path to GCP service account JSON (gcr); use - for stdin")
+	silenceUsageRecursive(registryCmd)
+}
+
+var registryCmd = &cobra.Command{
+	Use:          "registry",
+	Aliases:      []string{"registries"},
+	Short:        "Manage container registry credentials (ghcr, gcr, dockerhub)",
+	SilenceUsage: true,
+}
+
+var registryListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "Show which registries have credentials configured",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		var resp registryListResponse
+		if _, err := client.do("GET", "/api/registry-credentials", nil, nil, &resp); err != nil {
+			return err
+		}
+		if outputFormat == "json" {
+			return printJSON(resp)
+		}
+		fmt.Printf("%-12s  %-10s  %-30s  %s\n", "REGISTRY", "STATUS", "USERNAME", "UPDATED")
+		printRegistry := func(name string, s registryStatus) {
+			status := "missing"
+			if s.HasCredentials {
+				status = "ok"
+				if s.Expired {
+					status = "expired"
+				}
+			}
+			user := s.Username
+			if user == "" {
+				user = "-"
+			}
+			updated := s.UpdatedAt
+			if updated == "" {
+				updated = "-"
+			}
+			fmt.Printf("%-12s  %-10s  %-30s  %s\n", name, status, user, updated)
+		}
+		printRegistry(registryGHCR, resp.GHCR)
+		printRegistry(registryGCR, resp.GCR)
+		printRegistry(registryDockerHub, resp.DockerHub)
+		return nil
+	},
+}
+
+var registrySetCmd = &cobra.Command{
+	Use:   "set [ghcr|gcr|dockerhub]",
+	Short: "Set credentials for a registry",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		registry := strings.ToLower(args[0])
+		body, err := buildRegistryBody(registry, cmd)
+		if err != nil {
+			return err
+		}
+		var resp map[string]any
+		if _, err := client.do("PUT", pathf("/api/registry-credentials/%s", registry), nil, body, &resp); err != nil {
+			return err
+		}
+		if msg, ok := resp["message"].(string); ok && msg != "" {
+			fmt.Println(msg)
+			return nil
+		}
+		fmt.Printf("%s credentials updated\n", registry)
+		return nil
+	},
+}
+
+var registryDeleteCmd = &cobra.Command{
+	Use:     "delete [ghcr|gcr|dockerhub]",
+	Aliases: []string{"rm", "remove"},
+	Short:   "Delete credentials for a registry",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		registry := strings.ToLower(args[0])
+		if !validRegistry(registry) {
+			return fmt.Errorf("registry must be one of: %s, %s, %s", registryGHCR, registryGCR, registryDockerHub)
+		}
+		if _, err := client.do("DELETE", pathf("/api/registry-credentials/%s", registry), nil, nil, nil); err != nil {
+			return err
+		}
+		fmt.Printf("Deleted %s credentials\n", registry)
+		return nil
+	},
+}
+
+func validRegistry(name string) bool {
+	return name == registryGHCR || name == registryGCR || name == registryDockerHub
+}
+
+func buildRegistryBody(registry string, cmd *cobra.Command) (map[string]any, error) {
+	switch registry {
+	case registryGHCR, registryDockerHub:
+		if registryUsername == "" || registryToken == "" {
+			return nil, fmt.Errorf("--username and --token are required for %s", registry)
+		}
+		return map[string]any{"username": registryUsername, "token": registryToken}, nil
+	case registryGCR:
+		if registryKeyFile == "" {
+			return nil, fmt.Errorf("--key-file is required for gcr")
+		}
+		var (
+			data []byte
+			err  error
+		)
+		if registryKeyFile == "-" {
+			data, err = io.ReadAll(os.Stdin)
+		} else {
+			data, err = os.ReadFile(registryKeyFile)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading key file: %w", err)
+		}
+		return map[string]any{"key": strings.TrimSpace(string(data))}, nil
+	default:
+		return nil, fmt.Errorf("registry must be one of: %s, %s, %s", registryGHCR, registryGCR, registryDockerHub)
+	}
+}

--- a/secret.go
+++ b/secret.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type secretView struct {
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	CreatedAt string   `json:"created_at"`
+	UpdatedAt string   `json:"updated_at"`
+	UsedBy    []string `json:"used_by"`
+}
+
+var (
+	secretValue     string
+	secretValueFile string
+)
+
+func init() {
+	rootCmd.AddCommand(secretCmd)
+	secretCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "Output format: table or json")
+
+	secretCmd.AddCommand(secretListCmd, secretGetCmd, secretCreateCmd, secretSetCmd, secretDeleteCmd)
+
+	for _, cmd := range []*cobra.Command{secretCreateCmd, secretSetCmd} {
+		cmd.Flags().StringVar(&secretValue, "value", "", "Secret value (use --value-file or stdin to avoid leaking via process listing)")
+		cmd.Flags().StringVar(&secretValueFile, "value-file", "", "Read the secret value from this file (use - for stdin)")
+	}
+	silenceUsageRecursive(secretCmd)
+}
+
+var secretCmd = &cobra.Command{
+	Use:          "secret",
+	Aliases:      []string{"secrets"},
+	Short:        "Manage organization-level secrets",
+	SilenceUsage: true,
+}
+
+var secretListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List secrets in the organization vault",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		var list []secretView
+		if _, err := client.do("GET", "/api/secrets", nil, nil, &list); err != nil {
+			return err
+		}
+		if outputFormat == "json" {
+			return printJSON(list)
+		}
+		if len(list) == 0 {
+			fmt.Println("No secrets.")
+			return nil
+		}
+		fmt.Printf("%-32s  %-30s  %s\n", "NAME", "UPDATED", "USED BY")
+		for _, s := range list {
+			used := strings.Join(s.UsedBy, ", ")
+			if used == "" {
+				used = "-"
+			}
+			fmt.Printf("%-32s  %-30s  %s\n", truncate(s.Name, 32), truncate(s.UpdatedAt, 30), used)
+		}
+		return nil
+	},
+}
+
+var secretGetCmd = &cobra.Command{
+	Use:   "get [name]",
+	Short: "Show secret metadata (the value itself is never returned)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		var s secretView
+		if _, err := client.do("GET", pathf("/api/secrets/%s", args[0]), nil, nil, &s); err != nil {
+			return err
+		}
+		if outputFormat == "json" {
+			return printJSON(s)
+		}
+		fmt.Printf("Name:      %s\n", s.Name)
+		fmt.Printf("ID:        %s\n", s.ID)
+		fmt.Printf("Created:   %s\n", s.CreatedAt)
+		fmt.Printf("Updated:   %s\n", s.UpdatedAt)
+		used := strings.Join(s.UsedBy, ", ")
+		if used == "" {
+			used = "-"
+		}
+		fmt.Printf("Used by:   %s\n", used)
+		return nil
+	},
+}
+
+var secretCreateCmd = &cobra.Command{
+	Use:   "create [name]",
+	Short: "Create a new organization secret",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		value, err := readSecretValue(cmd)
+		if err != nil {
+			return err
+		}
+		body := map[string]any{"name": args[0], "value": value}
+		var s secretView
+		if _, err := client.do("POST", "/api/secrets", nil, body, &s); err != nil {
+			return err
+		}
+		fmt.Printf("Created secret %s\n", s.Name)
+		return nil
+	},
+}
+
+var secretSetCmd = &cobra.Command{
+	Use:   "set [name]",
+	Short: "Update the value of an existing secret",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		value, err := readSecretValue(cmd)
+		if err != nil {
+			return err
+		}
+		body := map[string]any{"value": value}
+		var s secretView
+		if _, err := client.do("PUT", pathf("/api/secrets/%s", args[0]), nil, body, &s); err != nil {
+			return err
+		}
+		fmt.Printf("Updated secret %s (containers using it will be marked stale)\n", s.Name)
+		return nil
+	},
+}
+
+var secretDeleteCmd = &cobra.Command{
+	Use:     "delete [name]",
+	Aliases: []string{"rm", "remove"},
+	Short:   "Delete a secret (fails if any container references it)",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		if _, err := client.do("DELETE", pathf("/api/secrets/%s", args[0]), nil, nil, nil); err != nil {
+			return err
+		}
+		fmt.Printf("Deleted secret %s\n", args[0])
+		return nil
+	},
+}
+
+// readSecretValue resolves the secret value from --value, --value-file, or
+// stdin (when no flags are given but data is piped in).
+func readSecretValue(cmd *cobra.Command) (string, error) {
+	hasInline := cmd.Flags().Changed("value")
+	hasFile := cmd.Flags().Changed("value-file")
+
+	if hasInline && hasFile {
+		return "", fmt.Errorf("--value and --value-file are mutually exclusive")
+	}
+
+	if hasFile {
+		if secretValueFile == "-" {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return "", fmt.Errorf("reading stdin: %w", err)
+			}
+			return strings.TrimRight(string(data), "\r\n"), nil
+		}
+		data, err := os.ReadFile(secretValueFile)
+		if err != nil {
+			return "", fmt.Errorf("reading %s: %w", secretValueFile, err)
+		}
+		return strings.TrimRight(string(data), "\r\n"), nil
+	}
+
+	if hasInline {
+		return secretValue, nil
+	}
+
+	// Fall back to stdin if it's a pipe.
+	stat, err := os.Stdin.Stat()
+	if err == nil && (stat.Mode()&os.ModeCharDevice) == 0 {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", fmt.Errorf("reading stdin: %w", err)
+		}
+		v := strings.TrimRight(string(data), "\r\n")
+		if v != "" {
+			return v, nil
+		}
+	}
+
+	return "", fmt.Errorf("provide a value via --value, --value-file, or stdin")
+}

--- a/ssh_key.go
+++ b/ssh_key.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type sshKeyView struct {
+	ID        string   `json:"id"`
+	Name      string   `json:"name"`
+	KeyType   string   `json:"key_type"`
+	CreatedAt string   `json:"created_at"`
+	UsedBy    []string `json:"used_by"`
+}
+
+var (
+	sshPublicKey     string
+	sshPublicKeyFile string
+)
+
+func init() {
+	rootCmd.AddCommand(sshKeyCmd)
+	sshKeyCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "Output format: table or json")
+
+	sshKeyCmd.AddCommand(sshKeyListCmd, sshKeyCreateCmd, sshKeyDeleteCmd)
+
+	sshKeyCreateCmd.Flags().StringVar(&sshPublicKey, "public-key", "", "Public key contents (e.g. \"ssh-ed25519 AAAA...\")")
+	sshKeyCreateCmd.Flags().StringVar(&sshPublicKeyFile, "public-key-file", "", "Read the public key from this file (use - for stdin)")
+	silenceUsageRecursive(sshKeyCmd)
+}
+
+var sshKeyCmd = &cobra.Command{
+	Use:          "ssh-key",
+	Aliases:      []string{"ssh-keys"},
+	Short:        "Manage organization SSH public keys (used by debug containers)",
+	SilenceUsage: true,
+}
+
+var sshKeyListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List SSH keys",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		var list []sshKeyView
+		if _, err := client.do("GET", "/api/ssh-keys", nil, nil, &list); err != nil {
+			return err
+		}
+		if outputFormat == "json" {
+			return printJSON(list)
+		}
+		if len(list) == 0 {
+			fmt.Println("No SSH keys.")
+			return nil
+		}
+		fmt.Printf("%-32s  %-12s  %s\n", "NAME", "TYPE", "USED BY")
+		for _, k := range list {
+			used := strings.Join(k.UsedBy, ", ")
+			if used == "" {
+				used = "-"
+			}
+			fmt.Printf("%-32s  %-12s  %s\n", truncate(k.Name, 32), k.KeyType, used)
+		}
+		return nil
+	},
+}
+
+var sshKeyCreateCmd = &cobra.Command{
+	Use:   "create [name]",
+	Short: "Add a public SSH key to the organization",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		key, err := readSSHPublicKey(cmd)
+		if err != nil {
+			return err
+		}
+		body := map[string]any{"name": args[0], "public_key": key}
+		var k sshKeyView
+		if _, err := client.do("POST", "/api/ssh-keys", nil, body, &k); err != nil {
+			return err
+		}
+		fmt.Printf("Added SSH key %s (%s)\n", k.Name, k.KeyType)
+		return nil
+	},
+}
+
+var sshKeyDeleteCmd = &cobra.Command{
+	Use:     "delete [name]",
+	Aliases: []string{"rm", "remove"},
+	Short:   "Delete an SSH key (fails if any container references it)",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		if _, err := client.do("DELETE", pathf("/api/ssh-keys/%s", args[0]), nil, nil, nil); err != nil {
+			return err
+		}
+		fmt.Printf("Deleted SSH key %s\n", args[0])
+		return nil
+	},
+}
+
+func readSSHPublicKey(cmd *cobra.Command) (string, error) {
+	hasInline := cmd.Flags().Changed("public-key")
+	hasFile := cmd.Flags().Changed("public-key-file")
+	if hasInline && hasFile {
+		return "", fmt.Errorf("--public-key and --public-key-file are mutually exclusive")
+	}
+	if hasFile {
+		if sshPublicKeyFile == "-" {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return "", fmt.Errorf("reading stdin: %w", err)
+			}
+			return strings.TrimSpace(string(data)), nil
+		}
+		data, err := os.ReadFile(sshPublicKeyFile)
+		if err != nil {
+			return "", fmt.Errorf("reading %s: %w", sshPublicKeyFile, err)
+		}
+		return strings.TrimSpace(string(data)), nil
+	}
+	if hasInline {
+		return strings.TrimSpace(sshPublicKey), nil
+	}
+	return "", fmt.Errorf("provide a public key via --public-key or --public-key-file")
+}


### PR DESCRIPTION
## Summary

Extends the CLI from verification-only to full container lifecycle management against the controlplane. Users can now create, deploy, update, stop/start, and delete containers — plus manage the org-level secrets, SSH keys, registry credentials, and custom domains they reference — without leaving the terminal.

Auth uses an admin API key (created in the dashboard). Saved to `~/.tinfoil/config.json` (mode 0600); `TINFOIL_API_KEY` / `TINFOIL_CONTROLPLANE_URL` override.

## New commands

- `login` / `logout` / `whoami`
- `container {list, get, create, delete, start, stop, relaunch, auto-update, metrics, hosts, group, update {status,accept,cancel}, connect}`
- `secret`, `ssh-key`, `registry`, `domain` (CRUD)
- `container connect <name>` — resolves enclave domain + config repo and runs the verified proxy in one step

## Test plan

- [x] `go build ./...` and `go test ./...` pass
- [x] Full lifecycle exercised end-to-end against `https://api.tinfoil.sh`: login → create against `tinfoilsh/tinfoil-containers-hello-world@v0.0.5` → poll to ready → metrics → relaunch + update cancel → connect (curl returned `Hello from a Tinfoil Container!` through the verified channel) → stop → start → delete
- [x] Resource CRUD: secret create/set/get/delete, ssh-key create/delete, auto-update on/off
- [x] All test resources cleaned up

Companion docs PR: tinfoilsh/docs (forthcoming).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full container lifecycle management to the Tinfoil CLI, org resource management, and a one-step verified connect. Enforces HTTPS for controlplane requests, path-escapes user input, hardens config loading, preserves group order when flags aren’t set, and adds a test ensuring HTTP URLs with embedded credentials are rejected.

- **New Features**
  - Auth commands: `login`, `logout`, `whoami`.
  - Containers: `list`, `get`, `create`, `delete`, `start`, `stop`, `relaunch`, `update {status,accept,cancel}`, `auto-update`, `metrics`, `hosts`, `group`, `connect`.
  - `container connect <name>` resolves enclave domain and repo, then runs the verified proxy.
  - Name matching: `--debug-mode` disambiguates containers when both debug and non-debug share a name.
  - Org resources: `secret`, `ssh-key`, `registry`, `domain` (CRUD).
  - `-o json` for machine-readable output on `list`/`get`.
  - Security: enforce HTTPS for controlplane requests; path-escape user-controlled URL segments to avoid traversal and misrouting.
  - Grouping: preserve existing `group_order`/`display_order` when flags are omitted.

- **Migration**
  - Create an admin API key in the dashboard, then run `tinfoil login` (or `tinfoil login --api-key <key>`).
  - Credentials are saved to `~/.tinfoil/config.json` (0600). Override with `TINFOIL_API_KEY`, `TINFOIL_CONTROLPLANE_URL` (HTTPS required; HTTP allowed only for localhost/127.0.0.1/::1), and `TINFOIL_CONFIG` for a custom path.
  - If the config file is malformed or unreadable, the CLI falls back to defaults and env vars; re-run `tinfoil login` to rewrite it.
  - Verify setup with `tinfoil whoami`.

<sup>Written for commit 8329b5ac1304dfa400d6150321a7f99647b7f910. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-cli/pull/80?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

