### PR TITLE
fix: publish multi-arch docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ jobs:
           go-version-file: go.mod
           cache: false
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - name: Docker Login
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,18 +8,20 @@ builds:
       - linux
       - darwin
 
-dockers:
-  - image_templates:
-      - "ghcr.io/tinfoilsh/tinfoil-cli:{{ .Version }}"
-      - "ghcr.io/tinfoilsh/tinfoil-cli:latest"
-    dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--pull"
-      - "--label=org.opencontainers.image.created={{ .Date }}"
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
+dockers_v2:
+  - images:
+      - "ghcr.io/tinfoilsh/tinfoil-cli"
+    tags:
+      - "{{ .Version }}"
+      - "latest"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      "org.opencontainers.image.created": "{{ .Date }}"
+      "org.opencontainers.image.title": "{{ .ProjectName }}"
+      "org.opencontainers.image.revision": "{{ .FullCommit }}"
+      "org.opencontainers.image.version": "{{ .Version }}"
 
 changelog:
   sort: asc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM alpine:latest
-COPY tinfoil /usr/bin/tinfoil
+ARG TARGETPLATFORM
+COPY ${TARGETPLATFORM}/tinfoil /usr/bin/tinfoil
 ENTRYPOINT ["/usr/bin/tinfoil"]


### PR DESCRIPTION
Fixes #77.

## Summary
- Publish the GHCR image as a linux/amd64 + linux/arm64 manifest via GoReleaser `dockers_v2`.
- Copy the platform-specific binary in the Dockerfile and set up QEMU/Buildx in release CI.

## Validation
- `go test ./...`
- YAML parse for release config/workflow
- Local Buildx amd64/arm64 image runs plus multi-platform OCI export

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish a multi-arch Docker image to GHCR for linux/amd64 and linux/arm64. This fixes broken ARM64 pulls and keeps one tag for both platforms.

- **Bug Fixes**
  - Switch to `GoReleaser` `dockers_v2` to push a multi-platform manifest to `ghcr.io/tinfoilsh/tinfoil-cli` with `latest` and version tags.
  - Add `docker/setup-qemu-action` and `docker/setup-buildx-action` in the release workflow for cross-arch builds.
  - Update Dockerfile to use `ARG TARGETPLATFORM` and copy `${TARGETPLATFORM}/tinfoil` for the correct binary.

<sup>Written for commit 232385fbac5b1f3fb012324c7cfab9f22beee8e1. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-cli/pull/81?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

