### PR TITLE
feat: default for proxy is to pick a random Tinfoil router

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The proxy verifies the enclave on startup (hardware attestation, Sigstore bundle
 tinfoil proxy -p 8080
 ```
 
-By default this connects to the public Tinfoil router. To proxy a specific enclave, pass `-e` and `-r`:
+By default this connects to the public Tinfoil router for inference. To proxy a specific enclave, pass `-e` and `-r`:
 
 ```bash
 tinfoil proxy \
@@ -52,7 +52,7 @@ docker run -p 8080:8080 ghcr.io/tinfoilsh/tinfoil-cli:<version> \
   proxy -b 0.0.0.0
 ```
 
-Add `-e <host> -r <owner/repo>` to target a specific enclave instead of the public router.
+Add `-e <host> -r <owner/repo>` to target a specific enclave instead of the Tinfoil router.
 
 Example `docker-compose.yml`:
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Run a local proxy that verifies enclave attestation and forwards requests. This 
 The proxy verifies the enclave on startup (hardware attestation, Sigstore bundle, measurement comparison) and pins the TLS certificate. If the certificate rotates, the proxy re-verifies automatically. If verification fails, requests are rejected.
 
 ```bash
+tinfoil proxy -p 8080
+```
+
+By default this connects to the public Tinfoil router. To proxy a specific enclave, pass `-e` and `-r`:
+
+```bash
 tinfoil proxy \
   -e inference.tinfoil.sh \
   -r tinfoilsh/confidential-model-router \
@@ -43,11 +49,10 @@ The proxy passes your `Authorization` header through to the enclave — it does 
 
 ```bash
 docker run -p 8080:8080 ghcr.io/tinfoilsh/tinfoil-cli:<version> \
-  proxy \
-  -e inference.tinfoil.sh \
-  -r tinfoilsh/confidential-model-router \
-  -b 0.0.0.0
+  proxy -b 0.0.0.0
 ```
+
+Add `-e <host> -r <owner/repo>` to target a specific enclave instead of the public router.
 
 Example `docker-compose.yml`:
 
@@ -57,8 +62,6 @@ services:
     image: ghcr.io/tinfoilsh/tinfoil-cli:<version>
     command: >
       proxy
-      -e inference.tinfoil.sh
-      -r tinfoilsh/confidential-model-router
       -b 0.0.0.0
       -p 8080
     ports:
@@ -76,8 +79,8 @@ services:
 |------|---------|-------------|
 | `-p, --port` | `8080` | Port to listen on |
 | `-b, --bind` | `127.0.0.1` | Address to bind to (use `0.0.0.0` in Docker) |
-| `-e, --host` | | Enclave hostname |
-| `-r, --repo` | | Enclave config repo |
+| `-e, --host` | public router | Enclave hostname (override to target a specific enclave; must be set together with `-r`) |
+| `-r, --repo` | public router | Enclave config repo (override to target a specific enclave; must be set together with `-e`) |
 | `--log-format` | `text` | `text` or `json` |
 
 ## HTTP Requests

--- a/proxy.go
+++ b/proxy.go
@@ -47,23 +47,33 @@ var proxyCmd = &cobra.Command{
 		trace, _ := cmd.Flags().GetBool("trace")
 		setupLogger(verbose, trace)
 
-		targetUrl, err := url.Parse("https://" + enclaveHost)
-		if err != nil {
-			log.WithError(err).Error("failed to parse upstream URL")
-			return err
-		}
-
 		log.WithFields(log.Fields{
 			"enclave_host": enclaveHost,
 			"repo":         repo,
 		}).Info("initializing secure client")
 
-		tinfoilClient, err := tinfoil.NewClientWithParams(enclaveHost, repo)
+		var tinfoilClient *tinfoil.Client
+		var err error
+		if enclaveHost == "" && repo == "" {
+			tinfoilClient, err = tinfoil.NewClient()
+			if err == nil {
+				enclaveHost = tinfoilClient.Enclave()
+				repo = tinfoilClient.Repo()
+			}
+		} else {
+			tinfoilClient, err = tinfoil.NewClientWithParams(enclaveHost, repo)
+		}
 		if err != nil {
 			log.WithError(err).Error("failed to create HTTP client")
 			return err
 		}
 		log.Debug("secure HTTP client created successfully")
+
+		targetUrl, err := url.Parse("https://" + enclaveHost)
+		if err != nil {
+			log.WithError(err).Error("failed to parse upstream URL")
+			return err
+		}
 
 		httpClient := tinfoilClient.HTTPClient()
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Default the proxy to auto-select a random Tinfoil router when no enclave is specified, so `tinfoil proxy` works out of the box. This simplifies setup and still allows targeting a specific enclave when needed.

- **New Features**
  - When `-e` and `-r` are omitted, use `tinfoil.NewClient()` to pick a Tinfoil router and populate `enclave_host` and `repo`.
  - To target a specific enclave, pass both `-e` and `-r` together.
  - README updated with simpler CLI/Docker examples and clarified flag defaults in the options table.

<sup>Written for commit 1cf2f705c46f2a1136933fc986034daadf28c9e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

