### PR TITLE
Mark the proxy command as deprecated

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -40,8 +40,9 @@ func setupLogger(verbose, trace bool) {
 }
 
 var proxyCmd = &cobra.Command{
-	Use:   "proxy",
-	Short: "Run a local HTTP proxy",
+	Use:        "proxy",
+	Short:      "Run a local HTTP proxy",
+	Deprecated: "the proxy has moved to github.com/tinfoilsh/tinfoil-proxy. Install the Tinfoil Tray app for a menu-bar UI, or run `go install github.com/tinfoilsh/tinfoil-proxy@latest` for the standalone `tinfoil-proxy` binary.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		verbose, _ := cmd.Flags().GetBool("verbose")
 		trace, _ := cmd.Flags().GetBool("trace")


### PR DESCRIPTION
The proxy is moved to a standalone repo: https://github.com/tinfoilsh/tinfoil-proxy 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecated the built-in `proxy` command and pointed users to the standalone `tinfoil-proxy` and the Tinfoil Tray app. Adds a deprecation message with install guidance.

- **Migration**
  - Use the Tinfoil Tray app for a menu-bar UI.
  - Or install the standalone binary: `go install github.com/tinfoilsh/tinfoil-proxy@latest` (repo: `github.com/tinfoilsh/tinfoil-proxy`).

<sup>Written for commit 4667b1a0722e408185b1d26ce37b89da84adfe7a. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-cli/pull/87?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

