### PR TITLE
named buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,31 @@ tinfoil domain delete api.example.com
 
 Pass `-o json` on any list/get to emit machine-readable JSON.
 
+## Named buckets (`nbucket`)
+
+`tinfoil nbucket` gives verified access to a personal **named-bucket** account — an encrypted key-value store keyed by human-readable names. Every call attests the running enclave (measurement check, Sigstore bundle, TLS pinning) before any data crosses the wire.
+
+The account is bound to a **master key** that the server never sees. Anything stored in your account is unreadable without it.
+
+### Logging in
+
+```bash
+tinfoil nbucket login                  # prompts for API key + master key
+tinfoil nbucket login --api-key tk_... # supply API key non-interactively
+tinfoil nbucket whoami                 # confirm credentials and re-verify the enclave
+tinfoil nbucket logout                 # forget API key and master key
+```
+
+The API key is written to `~/.tinfoil/config.json` (mode 0600). The **master key is stored in your OS keyring** (macOS Keychain, Linux Secret Service, Windows Credential Manager) — never in the config file. Override per-command with `TINFOIL_NBUCKET_API_KEY`, `TINFOIL_NBUCKET_MASTER`, `TINFOIL_NBUCKET_HOST`, `TINFOIL_NBUCKET_REPO`.
+
+### Listing names
+
+```bash
+tinfoil nbucket list
+```
+
+One name per line. An empty output means your account has no items (or hasn't been initialized).
+
 ## Building from Source
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ services:
 
 ### Proxy Options
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `-p, --port` | `8080` | Port to listen on |
-| `-b, --bind` | `127.0.0.1` | Address to bind to (use `0.0.0.0` in Docker) |
-| `-e, --host` | public router | Enclave hostname (override to target a specific enclave; must be set together with `-r`) |
-| `-r, --repo` | public router | Enclave config repo (override to target a specific enclave; must be set together with `-e`) |
-| `--log-format` | `text` | `text` or `json` |
+| Flag           | Default       | Description                                                                                 |
+| -------------- | ------------- | ------------------------------------------------------------------------------------------- |
+| `-p, --port`   | `8080`        | Port to listen on                                                                           |
+| `-b, --bind`   | `127.0.0.1`   | Address to bind to (use `0.0.0.0` in Docker)                                                |
+| `-e, --host`   | public router | Enclave hostname (override to target a specific enclave; must be set together with `-r`)    |
+| `-r, --repo`   | public router | Enclave config repo (override to target a specific enclave; must be set together with `-e`) |
+| `--log-format` | `text`        | `text` or `json`                                                                            |
 
 ## HTTP Requests
 
@@ -245,13 +245,59 @@ tinfoil nbucket logout                 # forget API key and master key
 
 The API key is written to `~/.tinfoil/config.json` (mode 0600). The **master key is stored in your OS keyring** (macOS Keychain, Linux Secret Service, Windows Credential Manager) — never in the config file. Override per-command with `TINFOIL_NBUCKET_API_KEY`, `TINFOIL_NBUCKET_MASTER`, `TINFOIL_NBUCKET_HOST`, `TINFOIL_NBUCKET_REPO`.
 
-### Listing names
+### Account
 
 ```bash
-tinfoil nbucket list
+tinfoil nbucket account          # does an account exist for this API key?
+tinfoil nbucket account delete   # tear it down (refuses if any items remain)
 ```
 
-One name per line. An empty output means your account has no items (or hasn't been initialized).
+### Items
+
+```bash
+# List names
+tinfoil nbucket list
+
+# Store a file. Named-bucket generates and stores an encryption key by default.
+tinfoil nbucket put my/photo.jpg -f ./photo.jpg
+
+# Bring your own encryption key (BYOK) — named-bucket never sees this key after
+# the upload. Required again on read. --key may be repeated for multi-slot items.
+KEY=$(openssl rand -base64 32)
+tinfoil nbucket put my/secret.txt -f ./secret.txt --key "$KEY"
+
+# Fetch — to stdout, a file, or a partial range
+tinfoil nbucket get my/photo.jpg -o ./photo.jpg
+tinfoil nbucket get my/secret.txt --key "$KEY" -o ./secret.txt
+tinfoil nbucket get my/photo.jpg --range bytes=0-1023 -o head.bin
+
+# Inspect without fetching the body
+tinfoil nbucket metadata my/photo.jpg   # bucket-level metadata (version, size, key fingerprints)
+tinfoil nbucket reveal   my/photo.jpg   # access token + managed key(s) stored in the name map
+
+# Delete
+tinfoil nbucket delete my/photo.jpg
+```
+
+### Encryption key slots
+
+Items can have multiple encryption keys; any one of them decrypts the item.
+
+```bash
+# Add another key slot. --proof-key is required only for BYOK items (no
+# managed key on the item).
+NEW=$(openssl rand -base64 32)
+tinfoil nbucket keys add my/secret.txt --new-key "$NEW" --proof-key "$KEY"
+
+# Remove a key slot. --proof-key is required for BYOK items or when removing
+# the managed key.
+tinfoil nbucket keys remove my/secret.txt --remove-key "$KEY" --proof-key "$NEW"
+
+# Removing the server-managed key requires --unmanage as an explicit
+# acknowledgement: after this, named-bucket cannot read the item without
+# one of your user-managed keys.
+tinfoil nbucket keys remove my/photo.jpg --remove-key "$MANAGED_KEY" --unmanage --proof-key "$NEW"
+```
 
 ## Building from Source
 

--- a/config.go
+++ b/config.go
@@ -13,14 +13,29 @@ import (
 const (
 	defaultControlplaneURL = "https://api.tinfoil.sh"
 
+	defaultNBucketHost = "named-bucket.tinfoil.sh"
+	defaultNBucketRepo = "tinfoilsh/named-bucket"
+
 	envAPIKey      = "TINFOIL_API_KEY"
 	envCPURL       = "TINFOIL_CONTROLPLANE_URL"
 	envConfigPath  = "TINFOIL_CONFIG"
+
+	envNBucketHost   = "TINFOIL_NBUCKET_HOST"
+	envNBucketRepo   = "TINFOIL_NBUCKET_REPO"
+	envNBucketAPIKey = "TINFOIL_NBUCKET_API_KEY"
+	envNBucketMaster = "TINFOIL_NBUCKET_MASTER"
 )
 
 type cliConfig struct {
-	ControlplaneURL string `json:"controlplane_url"`
-	APIKey          string `json:"api_key"`
+	ControlplaneURL string         `json:"controlplane_url"`
+	APIKey          string         `json:"api_key"`
+	NBucket         *nbucketConfig `json:"nbucket,omitempty"`
+}
+
+type nbucketConfig struct {
+	Host   string `json:"host"`
+	Repo   string `json:"repo"`
+	APIKey string `json:"api_key"`
 }
 
 func configPath() (string, error) {

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 // indirect
+	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/digitorus/pkcs7 v0.0.0-20250730155240-ffadbf3f398c // indirect
 	github.com/digitorus/timestamp v0.0.0-20250524132541-c45532741eea // indirect
@@ -45,6 +46,7 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.25.4 // indirect
 	github.com/go-openapi/validate v0.25.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/google/certificate-transparency-go v1.3.2 // indirect
 	github.com/google/go-containerregistry v0.20.7 // indirect
 	github.com/google/go-sev-guest v0.14.1 // indirect
@@ -77,6 +79,7 @@ require (
 	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/transparency-dev/formats v0.0.0-20260202103038-9975703229b3 // indirect
 	github.com/transparency-dev/merkle v0.0.2 // indirect
+	github.com/zalando/go-keyring v0.2.8 // indirect
 	go.mongodb.org/mongo-driver v1.17.8 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.64.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 h
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/danieljoos/wincred v1.2.0 h1:ozqKHaLK0W/ii4KVbbvluM91W2H3Sh0BncbUNPS7jLE=
 github.com/danieljoos/wincred v1.2.0/go.mod h1:FzQLLMKBFdvu+osBrnFODiv32YGwCfx0SkRa/eYHgec=
+github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
+github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/digitorus/pkcs7 v0.0.0-20230713084857-e76b763bdc49/go.mod h1:SKVExuS+vpu2l9IoOc0RwqE7NYnb0JlcFHFnEJkVDzc=
@@ -155,6 +157,8 @@ github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPE
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
@@ -336,6 +340,8 @@ github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
 github.com/zalando/go-keyring v0.2.3 h1:v9CUu9phlABObO4LPWycf+zwMG7nlbb3t/B5wa97yms=
 github.com/zalando/go-keyring v0.2.3/go.mod h1:HL4k+OXQfJUWaMnqyuSOc0drfGPX2b51Du6K+MRgZMk=
+github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
+github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 go.mongodb.org/mongo-driver v1.17.8 h1:BDP3+U3Y8K0vTrpqDJIRaXNhb/bKyoVeg6tIJsW5EhM=
 go.mongodb.org/mongo-driver v1.17.8/go.mod h1:LlOhpH5NUEfhxcAwG0UEkMqwYcc4JU18gtCdGudk/tQ=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/nbucket.go
+++ b/nbucket.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -34,16 +35,15 @@ func init() {
 var nbucketCmd = &cobra.Command{
 	Use:   "nbucket",
 	Short: "Manage named buckets in your personal Tinfoil account",
-	Long: `Verified access to your personal named-bucket account.
+	Long: `Access your personal named-bucket account.
 
-Each call performs the same enclave attestation that ` + "`tinfoil http get`" + ` does
-(measurement check + Sigstore bundle + TLS pinning) against the named-bucket
-enclave before any data leaves your machine.
-
-The master key is stored in the OS keyring (macOS Keychain / Linux Secret
+Your master key is stored in the OS keyring (macOS Keychain / Linux Secret
 Service / Windows Credential Manager). The API key is stored in
 ~/.tinfoil/config.json. Both can be overridden per-command via the env vars
-TINFOIL_NBUCKET_API_KEY and TINFOIL_NBUCKET_MASTER.`,
+TINFOIL_NBUCKET_API_KEY and TINFOIL_NBUCKET_MASTER.
+
+Read the docs [todo] for more
+`,
 }
 
 var nbucketLoginCmd = &cobra.Command{
@@ -200,14 +200,11 @@ func nbucketVerify(nb *nbucketConfig, apiKey, master string) error {
 }
 
 func nbucketList(nb *nbucketConfig, apiKey, master string) ([]string, error) {
-	sc := client.NewSecureClient(nb.Host, nb.Repo)
-	resp, err := sc.Get("https://"+nb.Host+"/list", map[string]string{
-		"Authorization": "Bearer " + apiKey,
-		"X-Master-Key":  master,
-	})
+	resp, err := nbucketDo(nb, apiKey, master, "GET", "/list", nil, nil)
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	switch resp.StatusCode {
 	case http.StatusOK:
 	case http.StatusUnauthorized:
@@ -215,15 +212,42 @@ func nbucketList(nb *nbucketConfig, apiKey, master string) ([]string, error) {
 	case http.StatusNotFound:
 		return nil, nil
 	default:
-		return nil, fmt.Errorf("server returned %d: %s", resp.StatusCode, string(resp.Body))
+		return nil, nbucketStatusError(resp)
 	}
 	var body struct {
 		Names []string `json:"names"`
 	}
-	if err := json.Unmarshal(resp.Body, &body); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		return nil, fmt.Errorf("decoding /list response: %w", err)
 	}
 	return body.Names, nil
+}
+
+func nbucketDo(nb *nbucketConfig, apiKey, master, method, path string, extra map[string]string, body io.Reader) (*http.Response, error) {
+	sc := client.NewSecureClient(nb.Host, nb.Repo)
+	httpClient, err := sc.HTTPClient()
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(method, "https://"+nb.Host+path, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("X-Master-Key", master)
+	for k, v := range extra {
+		req.Header.Set(k, v)
+	}
+	return httpClient.Do(req)
+}
+
+func nbucketStatusError(resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	msg := strings.TrimSpace(string(body))
+	if msg == "" {
+		return fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+	return fmt.Errorf("server returned %d: %s", resp.StatusCode, msg)
 }
 
 func requireNBucketAuth() (*nbucketConfig, string, string, error) {

--- a/nbucket.go
+++ b/nbucket.go
@@ -1,0 +1,293 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/tinfoilsh/tinfoil-go/verifier/client"
+	"github.com/zalando/go-keyring"
+	"golang.org/x/term"
+)
+
+const (
+	nbucketKeyringService = "tinfoil-cli"
+	nbucketKeyringAccount = "nbucket-master"
+)
+
+func init() {
+	rootCmd.AddCommand(nbucketCmd)
+	nbucketCmd.AddCommand(nbucketLoginCmd, nbucketLogoutCmd, nbucketWhoamiCmd, nbucketListCmd)
+	for _, c := range []*cobra.Command{nbucketCmd, nbucketLoginCmd, nbucketLogoutCmd, nbucketWhoamiCmd, nbucketListCmd} {
+		c.SilenceUsage = true
+	}
+	nbucketLoginCmd.Flags().String("host", "", "named-bucket enclave hostname (default "+defaultNBucketHost+")")
+	nbucketLoginCmd.Flags().String("repo", "", "named-bucket source repo (default "+defaultNBucketRepo+")")
+	nbucketLoginCmd.Flags().String("api-key", "", "Tinfoil API key (personal). If omitted, prompts on stdin")
+}
+
+var nbucketCmd = &cobra.Command{
+	Use:   "nbucket",
+	Short: "Manage named buckets in your personal Tinfoil account",
+	Long: `Verified access to your personal named-bucket account.
+
+Each call performs the same enclave attestation that ` + "`tinfoil http get`" + ` does
+(measurement check + Sigstore bundle + TLS pinning) against the named-bucket
+enclave before any data leaves your machine.
+
+The master key is stored in the OS keyring (macOS Keychain / Linux Secret
+Service / Windows Credential Manager). The API key is stored in
+~/.tinfoil/config.json. Both can be overridden per-command via the env vars
+TINFOIL_NBUCKET_API_KEY and TINFOIL_NBUCKET_MASTER.`,
+}
+
+var nbucketLoginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Save credentials for a named-bucket account",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		hostFlag, _ := cmd.Flags().GetString("host")
+		repoFlag, _ := cmd.Flags().GetString("repo")
+		keyFlag, _ := cmd.Flags().GetString("api-key")
+
+		cfg, _, err := loadConfig()
+		if err != nil {
+			return err
+		}
+
+		nb := cfg.NBucket
+		if nb == nil {
+			nb = &nbucketConfig{}
+		}
+		if hostFlag != "" {
+			nb.Host = stripScheme(hostFlag)
+		}
+		if nb.Host == "" {
+			nb.Host = defaultNBucketHost
+		}
+		if repoFlag != "" {
+			nb.Repo = repoFlag
+		}
+		if nb.Repo == "" {
+			nb.Repo = defaultNBucketRepo
+		}
+
+		apiKey := strings.TrimSpace(keyFlag)
+		if apiKey == "" {
+			apiKey, err = promptForSecret(fmt.Sprintf("Enter Tinfoil API key for %s: ", nb.Host))
+			if err != nil {
+				return err
+			}
+		}
+		if apiKey == "" {
+			return errors.New("api key is required")
+		}
+		nb.APIKey = apiKey
+
+		master, err := promptForSecret("Enter bucket master key (base64, 32 bytes): ")
+		if err != nil {
+			return err
+		}
+		if master == "" {
+			return errors.New("master key is required")
+		}
+
+		fmt.Fprintf(os.Stderr, "Verifying %s...\n", nb.Host)
+		if err := nbucketVerify(nb, apiKey, master); err != nil {
+			return fmt.Errorf("verification failed: %w", err)
+		}
+
+		if err := keyring.Set(nbucketKeyringService, nbucketKeyringAccount, master); err != nil {
+			return fmt.Errorf("storing master key in OS keyring: %w", err)
+		}
+
+		cfg.NBucket = nb
+		path, err := saveConfig(cfg)
+		if err != nil {
+			_ = keyring.Delete(nbucketKeyringService, nbucketKeyringAccount)
+			return err
+		}
+		fmt.Printf("Logged in to %s. Config saved to %s (master key in OS keyring).\n", nb.Host, path)
+		return nil
+	},
+}
+
+var nbucketLogoutCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "Remove stored named-bucket credentials",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, _, err := loadConfig()
+		if err != nil {
+			return err
+		}
+		hadConfig := cfg.NBucket != nil
+		cfg.NBucket = nil
+		path, err := saveConfig(cfg)
+		if err != nil {
+			return err
+		}
+
+		err = keyring.Delete(nbucketKeyringService, nbucketKeyringAccount)
+		hadMaster := err == nil
+		if err != nil && !errors.Is(err, keyring.ErrNotFound) {
+			fmt.Fprintf(os.Stderr, "warning: removing master key from keyring: %v\n", err)
+		}
+
+		switch {
+		case hadConfig && hadMaster:
+			fmt.Printf("Removed nbucket config from %s and master key from OS keyring.\n", path)
+		case hadConfig:
+			fmt.Printf("Removed nbucket config from %s.\n", path)
+		case hadMaster:
+			fmt.Println("Removed master key from OS keyring.")
+		default:
+			fmt.Println("No nbucket credentials to remove.")
+		}
+		return nil
+	},
+}
+
+var nbucketWhoamiCmd = &cobra.Command{
+	Use:   "whoami",
+	Short: "Show the current named-bucket login",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		nb, apiKey, master, err := requireNBucketAuth()
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Host:     %s\n", nb.Host)
+		fmt.Printf("Repo:     %s\n", nb.Repo)
+		fmt.Printf("API key:  %s\n", redactKey(apiKey))
+		fmt.Printf("Master:   %s\n", redactKey(master))
+
+		fmt.Fprintln(os.Stderr, "Verifying enclave and credentials...")
+		if err := nbucketVerify(nb, apiKey, master); err != nil {
+			return fmt.Errorf("verification failed: %w", err)
+		}
+		fmt.Println("Status:   authenticated")
+		return nil
+	},
+}
+
+var nbucketListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List names in your named-bucket account",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		nb, apiKey, master, err := requireNBucketAuth()
+		if err != nil {
+			return err
+		}
+		names, err := nbucketList(nb, apiKey, master)
+		if err != nil {
+			return err
+		}
+		for _, n := range names {
+			fmt.Println(n)
+		}
+		return nil
+	},
+}
+
+// nbucketVerify performs a verified GET /list and surfaces 401 specifically so
+// the user can tell "wrong master" from generic transport failures.
+func nbucketVerify(nb *nbucketConfig, apiKey, master string) error {
+	_, err := nbucketList(nb, apiKey, master)
+	return err
+}
+
+func nbucketList(nb *nbucketConfig, apiKey, master string) ([]string, error) {
+	sc := client.NewSecureClient(nb.Host, nb.Repo)
+	resp, err := sc.Get("https://"+nb.Host+"/list", map[string]string{
+		"Authorization": "Bearer " + apiKey,
+		"X-Master-Key":  master,
+	})
+	if err != nil {
+		return nil, err
+	}
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusUnauthorized:
+		return nil, errors.New("master key does not match this account (401)")
+	case http.StatusNotFound:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("server returned %d: %s", resp.StatusCode, string(resp.Body))
+	}
+	var body struct {
+		Names []string `json:"names"`
+	}
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		return nil, fmt.Errorf("decoding /list response: %w", err)
+	}
+	return body.Names, nil
+}
+
+func requireNBucketAuth() (*nbucketConfig, string, string, error) {
+	cfg, _, err := loadConfig()
+	if err != nil {
+		return nil, "", "", err
+	}
+	nb := cfg.NBucket
+	if nb == nil {
+		nb = &nbucketConfig{}
+	}
+	if v := strings.TrimSpace(os.Getenv(envNBucketHost)); v != "" {
+		nb.Host = stripScheme(v)
+	}
+	if v := strings.TrimSpace(os.Getenv(envNBucketRepo)); v != "" {
+		nb.Repo = v
+	}
+	apiKey := nb.APIKey
+	if v := strings.TrimSpace(os.Getenv(envNBucketAPIKey)); v != "" {
+		apiKey = v
+	}
+
+	if nb.Host == "" || nb.Repo == "" || apiKey == "" {
+		return nil, "", "", fmt.Errorf("not logged in to named-bucket: run `tinfoil nbucket login` or set %s/%s/%s", envNBucketHost, envNBucketAPIKey, envNBucketMaster)
+	}
+
+	master := strings.TrimSpace(os.Getenv(envNBucketMaster))
+	if master == "" {
+		v, err := keyring.Get(nbucketKeyringService, nbucketKeyringAccount)
+		if err != nil {
+			if errors.Is(err, keyring.ErrNotFound) {
+				return nil, "", "", fmt.Errorf("master key not found in OS keyring — run `tinfoil nbucket login` or set %s", envNBucketMaster)
+			}
+			return nil, "", "", fmt.Errorf("reading master key from OS keyring: %w", err)
+		}
+		master = v
+	}
+	return nb, apiKey, master, nil
+}
+
+func stripScheme(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	return strings.TrimRight(s, "/")
+}
+
+func promptForSecret(prompt string) (string, error) {
+	fmt.Fprint(os.Stderr, prompt)
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		raw, err := term.ReadPassword(int(os.Stdin.Fd()))
+		fmt.Fprintln(os.Stderr)
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(string(raw)), nil
+	}
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 0, 4096), 1<<20)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return "", err
+		}
+		return "", nil
+	}
+	return strings.TrimSpace(scanner.Text()), nil
+}

--- a/nbucket_ops.go
+++ b/nbucket_ops.go
@@ -1,0 +1,372 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	nbucketCmd.AddCommand(nbucketAccountCmd, nbucketGetCmd, nbucketPutCmd, nbucketDeleteCmd, nbucketMetadataCmd, nbucketRevealCmd, nbucketKeysCmd)
+	nbucketAccountCmd.AddCommand(nbucketAccountDeleteCmd)
+	nbucketKeysCmd.AddCommand(nbucketKeysAddCmd, nbucketKeysRemoveCmd)
+
+	for _, c := range []*cobra.Command{
+		nbucketAccountCmd, nbucketAccountDeleteCmd,
+		nbucketGetCmd, nbucketPutCmd, nbucketDeleteCmd,
+		nbucketMetadataCmd, nbucketRevealCmd,
+		nbucketKeysCmd, nbucketKeysAddCmd, nbucketKeysRemoveCmd,
+	} {
+		c.SilenceUsage = true
+	}
+
+	nbucketGetCmd.Flags().StringP("output", "o", "", "Write to file (default: stdout)")
+	nbucketGetCmd.Flags().String("key", "", "User-managed encryption key (base64); required for BYOK items")
+	nbucketGetCmd.Flags().String("range", "", "Byte range, e.g. bytes=0-1023")
+
+	nbucketPutCmd.Flags().StringP("file", "f", "", "File to upload (use - for stdin)")
+	_ = nbucketPutCmd.MarkFlagRequired("file")
+	nbucketPutCmd.Flags().StringArray("key", nil, "User-managed encryption key (base64); may be repeated. If omitted, named-bucket generates and stores one.")
+	nbucketPutCmd.Flags().Int64("length", -1, "Plaintext length in bytes (required when --file is -)")
+
+	nbucketKeysAddCmd.Flags().String("new-key", "", "New encryption key to add (base64 32 bytes)")
+	_ = nbucketKeysAddCmd.MarkFlagRequired("new-key")
+	nbucketKeysAddCmd.Flags().String("proof-key", "", "BYOK proof key (base64); required if the item has no server-managed key")
+
+	nbucketKeysRemoveCmd.Flags().String("remove-key", "", "Encryption key slot to remove (base64 32 bytes)")
+	_ = nbucketKeysRemoveCmd.MarkFlagRequired("remove-key")
+	nbucketKeysRemoveCmd.Flags().String("proof-key", "", "Proof key (base64); required for BYOK items or when removing the managed key")
+	nbucketKeysRemoveCmd.Flags().Bool("unmanage", false, "Acknowledge that removing the managed key drops named-bucket's ability to recover the item without a user-managed key")
+}
+
+var nbucketAccountCmd = &cobra.Command{
+	Use:   "account",
+	Short: "Show whether your named-bucket account exists",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		nb, apiKey, master, err := requireNBucketAuth()
+		if err != nil {
+			return err
+		}
+		resp, err := nbucketDo(nb, apiKey, master, "GET", "/account", nil, nil)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nbucketStatusError(resp)
+		}
+		var body struct {
+			Exists bool `json:"exists"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			return fmt.Errorf("decoding /account: %w", err)
+		}
+		if body.Exists {
+			fmt.Println("exists")
+		} else {
+			fmt.Println("not initialized")
+		}
+		return nil
+	},
+}
+
+var nbucketAccountDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete your named-bucket account (must be empty)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		nb, apiKey, master, err := requireNBucketAuth()
+		if err != nil {
+			return err
+		}
+		resp, err := nbucketDo(nb, apiKey, master, "DELETE", "/account", nil, nil)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		switch resp.StatusCode {
+		case http.StatusNoContent:
+			fmt.Println("account deleted")
+			return nil
+		case http.StatusBadRequest:
+			return fmt.Errorf("account has items — delete them first")
+		default:
+			return nbucketStatusError(resp)
+		}
+	},
+}
+
+var nbucketGetCmd = &cobra.Command{
+	Use:   "get <name>",
+	Short: "Fetch a named item",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		nb, apiKey, master, err := requireNBucketAuth()
+		if err != nil {
+			return err
+		}
+		out, _ := cmd.Flags().GetString("output")
+		key, _ := cmd.Flags().GetString("key")
+		rng, _ := cmd.Flags().GetString("range")
+
+		headers := map[string]string{}
+		if key != "" {
+			headers["X-Encryption-Key"] = key
+		}
+		if rng != "" {
+			headers["Range"] = rng
+		}
+
+		resp, err := nbucketDo(nb, apiKey, master, "GET", "/get/"+args[0], headers, nil)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+			return nbucketStatusError(resp)
+		}
+
+		w := os.Stdout
+		if out != "" && out != "-" {
+			f, err := os.Create(out)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			w = f
+		}
+		if _, err := io.Copy(w, resp.Body); err != nil {
+			return fmt.Errorf("streaming body: %w", err)
+		}
+		return nil
+	},
+}
+
+var nbucketPutCmd = &cobra.Command{
+	Use:   "put <name>",
+	Short: "Store a named item",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		nb, apiKey, master, err := requireNBucketAuth()
+		if err != nil {
+			return err
+		}
+		filePath, _ := cmd.Flags().GetString("file")
+		keys, _ := cmd.Flags().GetStringArray("key")
+		length, _ := cmd.Flags().GetInt64("length")
+
+		var src io.Reader
+		var plaintextLength int64
+		if filePath == "-" {
+			if length < 0 {
+				return fmt.Errorf("--length is required when reading from stdin")
+			}
+			src = os.Stdin
+			plaintextLength = length
+		} else {
+			f, err := os.Open(filePath)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			if length >= 0 {
+				plaintextLength = length
+			} else {
+				info, err := f.Stat()
+				if err != nil {
+					return err
+				}
+				plaintextLength = info.Size()
+			}
+			src = f
+		}
+
+		pr, pw := io.Pipe()
+		mw := multipart.NewWriter(pw)
+		go func() {
+			defer pw.Close()
+			defer mw.Close()
+			for _, k := range keys {
+				if err := mw.WriteField("encryption_keys", k); err != nil {
+					pw.CloseWithError(err)
+					return
+				}
+			}
+			if err := mw.WriteField("plaintext_length", strconv.FormatInt(plaintextLength, 10)); err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+			part, err := mw.CreateFormFile("data", path.Base(args[0]))
+			if err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+			if _, err := io.Copy(part, src); err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+		}()
+
+		resp, err := nbucketDo(nb, apiKey, master, "POST", "/put/"+args[0], map[string]string{
+			"Content-Type": mw.FormDataContentType(),
+		}, pr)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nbucketStatusError(resp)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		fmt.Println(strings.TrimSpace(string(body)))
+		return nil
+	},
+}
+
+var nbucketDeleteCmd = &cobra.Command{
+	Use:   "delete <name>",
+	Short: "Delete a named item",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		nb, apiKey, master, err := requireNBucketAuth()
+		if err != nil {
+			return err
+		}
+		resp, err := nbucketDo(nb, apiKey, master, "DELETE", "/delete/"+args[0], nil, nil)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			return nbucketStatusError(resp)
+		}
+		return nil
+	},
+}
+
+var nbucketMetadataCmd = &cobra.Command{
+	Use:   "metadata <name>",
+	Short: "Show object metadata for a named item",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return nbucketJSONGet("/metadata/"+args[0], nil)
+	},
+}
+
+var nbucketRevealCmd = &cobra.Command{
+	Use:   "reveal <name>",
+	Short: "Reveal the stored access token and managed key(s) for a named item",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return nbucketJSONGet("/reveal/"+args[0], nil)
+	},
+}
+
+var nbucketKeysCmd = &cobra.Command{
+	Use:   "keys",
+	Short: "Manage encryption key slots on a named item",
+}
+
+var nbucketKeysAddCmd = &cobra.Command{
+	Use:   "add <name>",
+	Short: "Add an encryption key slot",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		nb, apiKey, master, err := requireNBucketAuth()
+		if err != nil {
+			return err
+		}
+		newKey, _ := cmd.Flags().GetString("new-key")
+		proofKey, _ := cmd.Flags().GetString("proof-key")
+
+		body, err := json.Marshal(map[string]string{"new_encryption_key": newKey})
+		if err != nil {
+			return err
+		}
+		headers := map[string]string{"Content-Type": "application/json"}
+		if proofKey != "" {
+			headers["X-Encryption-Key"] = proofKey
+		}
+		resp, err := nbucketDo(nb, apiKey, master, "POST", "/keys/add/"+args[0], headers, bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			return nbucketStatusError(resp)
+		}
+		return nil
+	},
+}
+
+var nbucketKeysRemoveCmd = &cobra.Command{
+	Use:   "remove <name>",
+	Short: "Remove an encryption key slot",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		nb, apiKey, master, err := requireNBucketAuth()
+		if err != nil {
+			return err
+		}
+		removeKey, _ := cmd.Flags().GetString("remove-key")
+		proofKey, _ := cmd.Flags().GetString("proof-key")
+		unmanage, _ := cmd.Flags().GetBool("unmanage")
+
+		body, err := json.Marshal(map[string]any{
+			"remove_encryption_key": removeKey,
+			"unmanage":              unmanage,
+		})
+		if err != nil {
+			return err
+		}
+		headers := map[string]string{"Content-Type": "application/json"}
+		if proofKey != "" {
+			headers["X-Encryption-Key"] = proofKey
+		}
+		resp, err := nbucketDo(nb, apiKey, master, "POST", "/keys/remove/"+args[0], headers, bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			return nbucketStatusError(resp)
+		}
+		return nil
+	},
+}
+
+func nbucketJSONGet(path string, extraHeaders map[string]string) error {
+	nb, apiKey, master, err := requireNBucketAuth()
+	if err != nil {
+		return err
+	}
+	resp, err := nbucketDo(nb, apiKey, master, "GET", path, extraHeaders, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nbucketStatusError(resp)
+	}
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, raw, "", "  "); err != nil {
+		_, _ = os.Stdout.Write(raw)
+		fmt.Println()
+		return nil
+	}
+	_, _ = os.Stdout.Write(pretty.Bytes())
+	fmt.Println()
+	return nil
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `tinfoil nbucket` for verified access to personal named-bucket accounts. Adds full account, item, and key management, with enclave attestation before every request and the master key stored in the OS keyring.

- **New Features**
  - Subcommands: `login`, `logout`, `whoami`, `list`, `account` (`delete`), `get`, `put`, `delete`, `metadata`, `reveal`, `keys add`, `keys remove`.
  - Items: `put` from file or stdin (`--length`), `get` to stdout/file with `--range`, and `delete`.
  - Encryption: default managed key or BYOK (`--key`), multiple key slots, `keys add/remove`; removing the managed key requires `--unmanage` and optional `--proof-key`.
  - Auth/config: API key saved to `~/.tinfoil/config.json` (0600); master key via OS keyring. Env overrides: `TINFOIL_NBUCKET_API_KEY`, `TINFOIL_NBUCKET_MASTER`, `TINFOIL_NBUCKET_HOST`, `TINFOIL_NBUCKET_REPO`. Defaults: host `named-bucket.tinfoil.sh`, repo `tinfoilsh/named-bucket`. Config adds `NBucket` section (`host`, `repo`, `api_key`).
  - Docs: README adds usage for login, account, items, metadata/reveal, and key slot workflows.

- **Dependencies**
  - Add `github.com/zalando/go-keyring`, `github.com/danieljoos/wincred`, and `github.com/godbus/dbus/v5` for cross-platform keyring support.

<sup>Written for commit c90710a454c6118299024fafad78eba0fd87dca8. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/tinfoil-cli/pull/88?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

