### PR TITLE
feat: manage container releases from the CLI

### DIFF
--- a/controlplane.go
+++ b/controlplane.go
@@ -105,9 +105,8 @@ func (c *cpClient) do(method, path string, query url.Values, body any, out any) 
 
 // pathf builds a controlplane URL path by url.PathEscape-ing each segment
 // before substituting it into the printf-style format. Use this anywhere a
-// path component comes from user input or unverified server data — string
-// concatenation would let `..` or `/` in a name traverse to a different
-// endpoint than the one the command names.
+// path component comes from user input or unverified server data. Callers must
+// still reject exact `.` and `..` segments, which PathEscape leaves unchanged.
 func pathf(format string, segments ...string) string {
 	args := make([]any, len(segments))
 	for i, s := range segments {

--- a/repo.go
+++ b/repo.go
@@ -95,16 +95,12 @@ var repoConfigGetCmd = &cobra.Command{
 		if repoConfigRaw && outputFormat == "json" {
 			return fmt.Errorf("--raw and --output json cannot be used together")
 		}
-		owner, name, err := parseRepository(args[0])
-		if err != nil {
-			return err
-		}
-		client, err := authedClient()
+		repository, client, err := repositoryCommand(args[0])
 		if err != nil {
 			return err
 		}
 		var response repoConfigResponse
-		if _, err := client.do("GET", repoAPIPath(owner, name)+"/config", nil, nil, &response); err != nil {
+		if _, err := client.do("GET", repository.apiPath()+"/config", nil, nil, &response); err != nil {
 			return err
 		}
 		if outputFormat == "json" {
@@ -114,7 +110,7 @@ var repoConfigGetCmd = &cobra.Command{
 			fmt.Print(response.Raw)
 			return nil
 		}
-		fmt.Printf("Repository:       %s/%s\n", owner, name)
+		fmt.Printf("Repository:       %s/%s\n", repository.owner, repository.name)
 		fmt.Printf("Default branch:   %s\n", response.DefaultBranch)
 		fmt.Printf("Config exists:    %v\n", response.Exists)
 		fmt.Printf("Release workflow: %v\n", response.HasBuildWorkflow)
@@ -131,15 +127,11 @@ var repoConfigPRCmd = &cobra.Command{
 	Long:  "Open a pull request through the installed GitHub App. Do not put secret values in the config because the repository must be public.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		owner, name, err := parseRepository(args[0])
+		repository, client, err := repositoryCommand(args[0])
 		if err != nil {
 			return err
 		}
 		raw, err := readConfigInput(repoConfigFile)
-		if err != nil {
-			return err
-		}
-		client, err := authedClient()
 		if err != nil {
 			return err
 		}
@@ -148,7 +140,7 @@ var repoConfigPRCmd = &cobra.Command{
 			body["pr_body"] = repoPRBody
 		}
 		var response repoConfigPRResponse
-		if _, err := client.do("POST", repoAPIPath(owner, name)+"/config/pr", nil, body, &response); err != nil {
+		if _, err := client.do("POST", repository.apiPath()+"/config/pr", nil, body, &response); err != nil {
 			return err
 		}
 		if outputFormat == "json" {
@@ -170,20 +162,16 @@ var repoPRStatusCmd = &cobra.Command{
 	Short: "Show the status of a config pull request",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		owner, name, err := parseRepository(args[0])
-		if err != nil {
-			return err
-		}
 		number, err := strconv.Atoi(args[1])
 		if err != nil || number <= 0 {
 			return fmt.Errorf("pull request number must be a positive integer")
 		}
-		client, err := authedClient()
+		repository, client, err := repositoryCommand(args[0])
 		if err != nil {
 			return err
 		}
 		var response repoPullResponse
-		path := repoAPIPath(owner, name) + "/pulls/" + strconv.Itoa(number)
+		path := repository.apiPath() + "/pulls/" + strconv.Itoa(number)
 		if _, err := client.do("GET", path, nil, nil, &response); err != nil {
 			return err
 		}
@@ -208,16 +196,12 @@ var repoBuildInfoCmd = &cobra.Command{
 	Short: "Show the latest tag and suggested next version",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		owner, name, err := parseRepository(args[0])
-		if err != nil {
-			return err
-		}
-		client, err := authedClient()
+		repository, client, err := repositoryCommand(args[0])
 		if err != nil {
 			return err
 		}
 		var response repoBuildInfoResponse
-		if _, err := client.do("GET", repoAPIPath(owner, name)+"/build/info", nil, nil, &response); err != nil {
+		if _, err := client.do("GET", repository.apiPath()+"/build/info", nil, nil, &response); err != nil {
 			return err
 		}
 		if outputFormat == "json" {
@@ -238,17 +222,13 @@ var repoBuildRunCmd = &cobra.Command{
 	Short: "Trigger the Tinfoil Release workflow",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		owner, name, err := parseRepository(args[0])
-		if err != nil {
-			return err
-		}
-		client, err := authedClient()
+		repository, client, err := repositoryCommand(args[0])
 		if err != nil {
 			return err
 		}
 		var response repoBuildResponse
 		body := map[string]string{"version": repoVersion}
-		if _, err := client.do("POST", repoAPIPath(owner, name)+"/build", nil, body, &response); err != nil {
+		if _, err := client.do("POST", repository.apiPath()+"/build", nil, body, &response); err != nil {
 			return err
 		}
 		if outputFormat == "json" {
@@ -260,16 +240,37 @@ var repoBuildRunCmd = &cobra.Command{
 	},
 }
 
-func parseRepository(value string) (string, string, error) {
-	owner, name, ok := strings.Cut(strings.TrimSpace(value), "/")
-	if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
-		return "", "", fmt.Errorf("repository must be in owner/repo format")
-	}
-	return owner, name, nil
+type repositoryRef struct {
+	owner string
+	name  string
 }
 
-func repoAPIPath(owner, name string) string {
-	return pathf("/api/github/repos/%s/%s", owner, name)
+func parseRepository(value string) (repositoryRef, error) {
+	owner, name, ok := strings.Cut(strings.TrimSpace(value), "/")
+	if !ok || !validRepositorySegment(owner) || !validRepositorySegment(name) || strings.Contains(name, "/") {
+		return repositoryRef{}, fmt.Errorf("repository must be in owner/repo format")
+	}
+	return repositoryRef{owner: owner, name: name}, nil
+}
+
+func validRepositorySegment(value string) bool {
+	return value != "" && value != "." && value != ".."
+}
+
+func (r repositoryRef) apiPath() string {
+	return pathf("/api/github/repos/%s/%s", r.owner, r.name)
+}
+
+func repositoryCommand(value string) (repositoryRef, *cpClient, error) {
+	repository, err := parseRepository(value)
+	if err != nil {
+		return repositoryRef{}, nil, err
+	}
+	client, err := authedClient()
+	if err != nil {
+		return repositoryRef{}, nil, err
+	}
+	return repository, client, nil
 }
 
 func readConfigInput(path string) (string, error) {

--- a/repo.go
+++ b/repo.go
@@ -1,0 +1,303 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const maxConfigFileBytes = 20 * 1024 * 1024
+
+type repoConfigResponse struct {
+	Success          bool            `json:"success"`
+	Config           json.RawMessage `json:"config"`
+	Raw              string          `json:"raw"`
+	Exists           bool            `json:"exists"`
+	FileSHA          string          `json:"file_sha"`
+	DefaultBranch    string          `json:"default_branch"`
+	HasBuildWorkflow bool            `json:"has_build_workflow"`
+}
+
+type repoConfigPRResponse struct {
+	Success  bool   `json:"success"`
+	PRURL    string `json:"pr_url"`
+	PRNumber int    `json:"pr_number"`
+	Branch   string `json:"branch"`
+}
+
+type repoPullResponse struct {
+	Success  bool   `json:"success"`
+	PRNumber int    `json:"pr_number"`
+	State    string `json:"state"`
+	Merged   bool   `json:"merged"`
+	PRURL    string `json:"pr_url"`
+}
+
+type repoBuildInfoResponse struct {
+	Success              bool   `json:"success"`
+	LatestTag            string `json:"latest_tag"`
+	SuggestedNextVersion string `json:"suggested_next_version"`
+}
+
+type repoBuildResponse struct {
+	Success        bool   `json:"success"`
+	Version        string `json:"version"`
+	WorkflowRunURL string `json:"workflow_run_url"`
+}
+
+var (
+	repoConfigRaw  bool
+	repoConfigFile string
+	repoPRBody     string
+	repoVersion    string
+)
+
+func init() {
+	rootCmd.AddCommand(repoCmd)
+	repoCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "Output format: table or json")
+	repoCmd.AddCommand(repoConfigCmd, repoPRCmd, repoBuildCmd)
+	repoConfigCmd.AddCommand(repoConfigGetCmd, repoConfigPRCmd)
+	repoPRCmd.AddCommand(repoPRStatusCmd)
+	repoBuildCmd.AddCommand(repoBuildInfoCmd, repoBuildRunCmd)
+
+	repoConfigGetCmd.Flags().BoolVar(&repoConfigRaw, "raw", false, "Print only the raw tinfoil-config.yml")
+	repoConfigPRCmd.Flags().StringVar(&repoConfigFile, "file", "", "Path to tinfoil-config.yml; use - for stdin")
+	repoConfigPRCmd.Flags().StringVar(&repoPRBody, "body", "", "Optional pull request description")
+	repoBuildRunCmd.Flags().StringVar(&repoVersion, "version", "", "Release version (for example v1.2.3)")
+	_ = repoConfigPRCmd.MarkFlagRequired("file")
+	_ = repoBuildRunCmd.MarkFlagRequired("version")
+
+	silenceUsageRecursive(repoCmd)
+}
+
+var repoCmd = &cobra.Command{
+	Use:          "repo",
+	Aliases:      []string{"repository", "repositories"},
+	Short:        "Manage container config repositories",
+	SilenceUsage: true,
+}
+
+var repoConfigCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Read or propose changes to tinfoil-config.yml",
+}
+
+var repoConfigGetCmd = &cobra.Command{
+	Use:   "get [owner/repo]",
+	Short: "Fetch tinfoil-config.yml through the installed GitHub App",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if repoConfigRaw && outputFormat == "json" {
+			return fmt.Errorf("--raw and --output json cannot be used together")
+		}
+		owner, name, err := parseRepository(args[0])
+		if err != nil {
+			return err
+		}
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		var response repoConfigResponse
+		if _, err := client.do("GET", repoAPIPath(owner, name)+"/config", nil, nil, &response); err != nil {
+			return err
+		}
+		if outputFormat == "json" {
+			return printJSON(response)
+		}
+		if repoConfigRaw {
+			fmt.Print(response.Raw)
+			return nil
+		}
+		fmt.Printf("Repository:       %s/%s\n", owner, name)
+		fmt.Printf("Default branch:   %s\n", response.DefaultBranch)
+		fmt.Printf("Config exists:    %v\n", response.Exists)
+		fmt.Printf("Release workflow: %v\n", response.HasBuildWorkflow)
+		if response.Raw != "" {
+			fmt.Printf("\n%s", response.Raw)
+		}
+		return nil
+	},
+}
+
+var repoConfigPRCmd = &cobra.Command{
+	Use:   "pr [owner/repo]",
+	Short: "Open a pull request with a local tinfoil-config.yml",
+	Long:  "Open a pull request through the installed GitHub App. Do not put secret values in the config because the repository must be public.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		owner, name, err := parseRepository(args[0])
+		if err != nil {
+			return err
+		}
+		raw, err := readConfigInput(repoConfigFile)
+		if err != nil {
+			return err
+		}
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		body := map[string]any{"raw": raw}
+		if repoPRBody != "" {
+			body["pr_body"] = repoPRBody
+		}
+		var response repoConfigPRResponse
+		if _, err := client.do("POST", repoAPIPath(owner, name)+"/config/pr", nil, body, &response); err != nil {
+			return err
+		}
+		if outputFormat == "json" {
+			return printJSON(response)
+		}
+		fmt.Printf("Opened pull request #%d: %s\n", response.PRNumber, response.PRURL)
+		fmt.Printf("Branch: %s\n", response.Branch)
+		return nil
+	},
+}
+
+var repoPRCmd = &cobra.Command{
+	Use:   "pr",
+	Short: "Inspect config pull requests",
+}
+
+var repoPRStatusCmd = &cobra.Command{
+	Use:   "status [owner/repo] [number]",
+	Short: "Show the status of a config pull request",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		owner, name, err := parseRepository(args[0])
+		if err != nil {
+			return err
+		}
+		number, err := strconv.Atoi(args[1])
+		if err != nil || number <= 0 {
+			return fmt.Errorf("pull request number must be a positive integer")
+		}
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		var response repoPullResponse
+		path := repoAPIPath(owner, name) + "/pulls/" + strconv.Itoa(number)
+		if _, err := client.do("GET", path, nil, nil, &response); err != nil {
+			return err
+		}
+		if outputFormat == "json" {
+			return printJSON(response)
+		}
+		fmt.Printf("Pull request: #%d\n", response.PRNumber)
+		fmt.Printf("State:        %s\n", response.State)
+		fmt.Printf("Merged:       %v\n", response.Merged)
+		fmt.Printf("URL:          %s\n", response.PRURL)
+		return nil
+	},
+}
+
+var repoBuildCmd = &cobra.Command{
+	Use:   "build",
+	Short: "Inspect or trigger the Tinfoil Release workflow",
+}
+
+var repoBuildInfoCmd = &cobra.Command{
+	Use:   "info [owner/repo]",
+	Short: "Show the latest tag and suggested next version",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		owner, name, err := parseRepository(args[0])
+		if err != nil {
+			return err
+		}
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		var response repoBuildInfoResponse
+		if _, err := client.do("GET", repoAPIPath(owner, name)+"/build/info", nil, nil, &response); err != nil {
+			return err
+		}
+		if outputFormat == "json" {
+			return printJSON(response)
+		}
+		latest := response.LatestTag
+		if latest == "" {
+			latest = "-"
+		}
+		fmt.Printf("Latest tag:             %s\n", latest)
+		fmt.Printf("Suggested next version: %s\n", response.SuggestedNextVersion)
+		return nil
+	},
+}
+
+var repoBuildRunCmd = &cobra.Command{
+	Use:   "run [owner/repo]",
+	Short: "Trigger the Tinfoil Release workflow",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		owner, name, err := parseRepository(args[0])
+		if err != nil {
+			return err
+		}
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		var response repoBuildResponse
+		body := map[string]string{"version": repoVersion}
+		if _, err := client.do("POST", repoAPIPath(owner, name)+"/build", nil, body, &response); err != nil {
+			return err
+		}
+		if outputFormat == "json" {
+			return printJSON(response)
+		}
+		fmt.Printf("Triggered release %s\n", response.Version)
+		fmt.Printf("GitHub Actions: %s\n", response.WorkflowRunURL)
+		return nil
+	},
+}
+
+func parseRepository(value string) (string, string, error) {
+	owner, name, ok := strings.Cut(strings.TrimSpace(value), "/")
+	if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
+		return "", "", fmt.Errorf("repository must be in owner/repo format")
+	}
+	return owner, name, nil
+}
+
+func repoAPIPath(owner, name string) string {
+	return pathf("/api/github/repos/%s/%s", owner, name)
+}
+
+func readConfigInput(path string) (string, error) {
+	var (
+		reader io.Reader
+		file   *os.File
+		err    error
+	)
+	if path == "-" {
+		reader = os.Stdin
+	} else {
+		file, err = os.Open(path)
+		if err != nil {
+			return "", fmt.Errorf("opening config file: %w", err)
+		}
+		defer file.Close()
+		reader = file
+	}
+
+	data, err := io.ReadAll(io.LimitReader(reader, maxConfigFileBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("reading config file: %w", err)
+	}
+	if len(data) > maxConfigFileBytes {
+		return "", fmt.Errorf("config file exceeds %d bytes", maxConfigFileBytes)
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return "", fmt.Errorf("config file is empty")
+	}
+	return string(data), nil
+}

--- a/repo_test.go
+++ b/repo_test.go
@@ -23,11 +23,15 @@ func TestParseRepository(t *testing.T) {
 		{value: "/example", wantError: true},
 		{value: "tinfoilsh/", wantError: true},
 		{value: "tinfoilsh/example/extra", wantError: true},
+		{value: "../example", wantError: true},
+		{value: "./example", wantError: true},
+		{value: "tinfoilsh/..", wantError: true},
+		{value: "tinfoilsh/.", wantError: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.value, func(t *testing.T) {
-			owner, repo, err := parseRepository(tt.value)
+			repository, err := parseRepository(tt.value)
 			if tt.wantError {
 				if err == nil {
 					t.Fatal("expected an error")
@@ -37,8 +41,8 @@ func TestParseRepository(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parseRepository: %v", err)
 			}
-			if owner != tt.wantOwner || repo != tt.wantRepo {
-				t.Fatalf("got %q/%q, want %q/%q", owner, repo, tt.wantOwner, tt.wantRepo)
+			if repository.owner != tt.wantOwner || repository.name != tt.wantRepo {
+				t.Fatalf("got %q/%q, want %q/%q", repository.owner, repository.name, tt.wantOwner, tt.wantRepo)
 			}
 		})
 	}

--- a/repo_test.go
+++ b/repo_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseRepository(t *testing.T) {
+	tests := []struct {
+		value     string
+		wantOwner string
+		wantRepo  string
+		wantError bool
+	}{
+		{value: "tinfoilsh/example", wantOwner: "tinfoilsh", wantRepo: "example"},
+		{value: " tinfoilsh/example ", wantOwner: "tinfoilsh", wantRepo: "example"},
+		{value: "example", wantError: true},
+		{value: "/example", wantError: true},
+		{value: "tinfoilsh/", wantError: true},
+		{value: "tinfoilsh/example/extra", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			owner, repo, err := parseRepository(tt.value)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseRepository: %v", err)
+			}
+			if owner != tt.wantOwner || repo != tt.wantRepo {
+				t.Fatalf("got %q/%q, want %q/%q", owner, repo, tt.wantOwner, tt.wantRepo)
+			}
+		})
+	}
+}
+
+func TestRepoConfigPRUsesAdminKeyAndRawConfig(t *testing.T) {
+	raw := "cpus: 2\nmemory: 8192\ncontainers: []\n"
+	path := filepath.Join(t.TempDir(), "tinfoil-config.yml")
+	if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/github/repos/acme/app/config/pr" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer admin_test" {
+			t.Errorf("authorization = %q", got)
+		}
+		var body struct {
+			Raw    string `json:"raw"`
+			PRBody string `json:"pr_body"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		if body.Raw != raw {
+			t.Errorf("raw config changed: %q", body.Raw)
+		}
+		if body.PRBody != "Update resources" {
+			t.Errorf("pr_body = %q", body.PRBody)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"success":true,"pr_url":"https://github.com/acme/app/pull/4","pr_number":4,"branch":"tinfoil/config-update-4"}`)
+	}))
+	defer server.Close()
+
+	configureRepoCommandTest(t, server.URL)
+	repoConfigFile = path
+	repoPRBody = "Update resources"
+
+	if err := repoConfigPRCmd.RunE(repoConfigPRCmd, []string{"acme/app"}); err != nil {
+		t.Fatalf("run config pr: %v", err)
+	}
+}
+
+func TestRepoBuildRunDispatchesVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/github/repos/acme/app/build" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		if body["version"] != "v1.2.3" {
+			t.Errorf("version = %q", body["version"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"success":true,"version":"v1.2.3","workflow_run_url":"https://github.com/acme/app/actions"}`)
+	}))
+	defer server.Close()
+
+	configureRepoCommandTest(t, server.URL)
+	repoVersion = "v1.2.3"
+
+	if err := repoBuildRunCmd.RunE(repoBuildRunCmd, []string{"acme/app"}); err != nil {
+		t.Fatalf("run build: %v", err)
+	}
+}
+
+func TestReadConfigInputRejectsOversizedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "large.yml")
+	data := make([]byte, maxConfigFileBytes+1)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if _, err := readConfigInput(path); err == nil {
+		t.Fatal("expected oversized config error")
+	}
+}
+
+func configureRepoCommandTest(t *testing.T, serverURL string) {
+	t.Helper()
+	t.Setenv(envCPURL, serverURL)
+	t.Setenv(envAPIKey, "admin_test")
+	t.Setenv(envConfigPath, filepath.Join(t.TempDir(), "missing-config.json"))
+
+	previousOutput := outputFormat
+	previousFile := repoConfigFile
+	previousBody := repoPRBody
+	previousVersion := repoVersion
+	outputFormat = "table"
+	repoConfigFile = ""
+	repoPRBody = ""
+	repoVersion = ""
+	t.Cleanup(func() {
+		outputFormat = previousOutput
+		repoConfigFile = previousFile
+		repoPRBody = previousBody
+		repoVersion = previousVersion
+	})
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `repo` commands to the CLI to fetch and propose `tinfoil-config.yml`, check PR status, and trigger release builds. Also hardens repository path validation.

- **New Features**
  - New `repo` command with: `config get`, `config pr`, `pr status`, `build info`, `build run`.
  - Flags: `-o json`, `--raw`, `--file` (supports `-` for stdin), `--body`, `--version`.
  - Validation: owner/repo format; reject `.` and `..` segments; no extra slashes; positive PR number; 20MB config limit; empty file check; block `--raw` with `-o json`.
  - Output: human-readable by default, structured JSON when requested.
  - Tests cover parse validation, API auth and payloads, version dispatch, and oversized config rejection.

<sup>Written for commit 7f61bf5b0676023824e64181f287ec4cc93b4e2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-cli/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

