### PR TITLE
Manage container deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,6 @@ tinfoil container update status my-container
 tinfoil container update accept my-container
 tinfoil container update cancel my-container
 
-# Auto-update (GitHub-connected containers)
-tinfoil container auto-update my-container --on
-tinfoil container auto-update my-container --off
-
 # Open a verified proxy to a deployed container
 tinfoil container connect my-container -p 8080
 ```

--- a/container.go
+++ b/container.go
@@ -39,8 +39,6 @@ type containerView struct {
 	Staging            bool            `json:"staging"`
 	DisableCCMode      bool            `json:"disable_cc_mode"`
 	GithubAppConnected bool            `json:"github_app_connected"`
-	GroupName          *string         `json:"group_name"`
-	GroupOrder         int32           `json:"group_order"`
 	DisplayOrder       int32           `json:"display_order"`
 	UpdateTag          string          `json:"update_tag"`
 	UpdateStatus       string          `json:"update_status"`
@@ -278,11 +276,7 @@ var containerCreateCmd = &cobra.Command{
 			"repo": createRepo,
 			"tag":  createTag,
 		}
-		if createGroupName != "" {
-			body["group_name"] = createGroupName
-			body["group_order"] = createGroupOrder
-			body["display_order"] = createDisplayOrder
-		} else if cmd.Flags().Changed("display-order") {
+		if cmd.Flags().Changed("display-order") {
 			body["display_order"] = createDisplayOrder
 		}
 		if len(vars) > 0 {
@@ -317,7 +311,7 @@ var containerCreateCmd = &cobra.Command{
 		if _, err := client.do("POST", "/api/containers", nil, body, &created); err != nil {
 			return err
 		}
-		if createGroupName != "" && created.DeploymentID != "" {
+		if createGroupName != "" {
 			deployment, err := resolveDeploymentForContainer(client, created)
 			if err != nil {
 				return fmt.Errorf("container created, but deployment group could not be set: %w", err)
@@ -513,11 +507,15 @@ var containerGroupCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		groupOrderToSend := c.GroupOrder
+		deployment, err := resolveDeploymentForContainer(client, *c)
+		if err != nil {
+			return err
+		}
+		groupOrderToSend := deployment.GroupOrder
 		if cmd.Flags().Changed("group-order") {
 			groupOrderToSend = groupOrder
 		}
-		displayOrderToSend := c.DisplayOrder
+		displayOrderToSend := deployment.DisplayOrder
 		if cmd.Flags().Changed("display-order") {
 			displayOrderToSend = groupDisplayOrder
 		}
@@ -527,40 +525,18 @@ var containerGroupCmd = &cobra.Command{
 		} else {
 			groupNameToSend = &groupName
 		}
-		if c.DeploymentID != "" {
-			deployment, err := resolveDeploymentForContainer(client, *c)
-			if err != nil {
-				return err
-			}
-			if !cmd.Flags().Changed("group-order") {
-				groupOrderToSend = deployment.GroupOrder
-			}
-			if !cmd.Flags().Changed("display-order") {
-				displayOrderToSend = deployment.DisplayOrder
-			}
-			updated, err := moveDeploymentToGroup(
-				client,
-				deployment.ID,
-				groupNameToSend,
-				groupOrderToSend,
-				displayOrderToSend,
-			)
-			if err != nil {
-				return err
-			}
-			updated = preserveDeploymentCounts(updated, *deployment)
-			return renderDeployment(updated)
-		}
-		body := map[string]any{
-			"group_name":    groupNameToSend,
-			"group_order":   groupOrderToSend,
-			"display_order": displayOrderToSend,
-		}
-		var updated containerView
-		if _, err := client.do("PUT", pathf("/api/containers/%s/group", c.ID), nil, body, &updated); err != nil {
+		updated, err := moveDeploymentToGroup(
+			client,
+			deployment.ID,
+			groupNameToSend,
+			groupOrderToSend,
+			displayOrderToSend,
+		)
+		if err != nil {
 			return err
 		}
-		return renderContainer(updated)
+		updated = preserveDeploymentCounts(updated, *deployment)
+		return renderDeployment(updated)
 	},
 }
 

--- a/container.go
+++ b/container.go
@@ -39,6 +39,9 @@ type containerView struct {
 	Staging            bool            `json:"staging"`
 	DisableCCMode      bool            `json:"disable_cc_mode"`
 	GithubAppConnected bool            `json:"github_app_connected"`
+	GroupName          *string         `json:"group_name"`
+	GroupOrder         int32           `json:"group_order"`
+	DisplayOrder       int32           `json:"display_order"`
 	UpdateTag          string          `json:"update_tag"`
 	UpdateStatus       string          `json:"update_status"`
 	UpdateType         string          `json:"update_type"`
@@ -314,7 +317,7 @@ var containerCreateCmd = &cobra.Command{
 		if _, err := client.do("POST", "/api/containers", nil, body, &created); err != nil {
 			return err
 		}
-		if createGroupName != "" {
+		if createGroupName != "" && created.DeploymentID != "" {
 			deployment, err := resolveDeploymentForContainer(client, created)
 			if err != nil {
 				return fmt.Errorf("container created, but deployment group could not be set: %w", err)
@@ -510,15 +513,11 @@ var containerGroupCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		deployment, err := resolveDeploymentForContainer(client, *c)
-		if err != nil {
-			return err
-		}
-		groupOrderToSend := deployment.GroupOrder
+		groupOrderToSend := c.GroupOrder
 		if cmd.Flags().Changed("group-order") {
 			groupOrderToSend = groupOrder
 		}
-		displayOrderToSend := deployment.DisplayOrder
+		displayOrderToSend := c.DisplayOrder
 		if cmd.Flags().Changed("display-order") {
 			displayOrderToSend = groupDisplayOrder
 		}
@@ -528,17 +527,40 @@ var containerGroupCmd = &cobra.Command{
 		} else {
 			groupNameToSend = &groupName
 		}
-		updated, err := moveDeploymentToGroup(
-			client,
-			deployment.ID,
-			groupNameToSend,
-			groupOrderToSend,
-			displayOrderToSend,
-		)
-		if err != nil {
+		if c.DeploymentID != "" {
+			deployment, err := resolveDeploymentForContainer(client, *c)
+			if err != nil {
+				return err
+			}
+			if !cmd.Flags().Changed("group-order") {
+				groupOrderToSend = deployment.GroupOrder
+			}
+			if !cmd.Flags().Changed("display-order") {
+				displayOrderToSend = deployment.DisplayOrder
+			}
+			updated, err := moveDeploymentToGroup(
+				client,
+				deployment.ID,
+				groupNameToSend,
+				groupOrderToSend,
+				displayOrderToSend,
+			)
+			if err != nil {
+				return err
+			}
+			updated = preserveDeploymentCounts(updated, *deployment)
+			return renderDeployment(updated)
+		}
+		body := map[string]any{
+			"group_name":    groupNameToSend,
+			"group_order":   groupOrderToSend,
+			"display_order": displayOrderToSend,
+		}
+		var updated containerView
+		if _, err := client.do("PUT", pathf("/api/containers/%s/group", c.ID), nil, body, &updated); err != nil {
 			return err
 		}
-		return renderDeployment(updated)
+		return renderContainer(updated)
 	},
 }
 

--- a/container.go
+++ b/container.go
@@ -96,9 +96,6 @@ var (
 	groupDisplayOrder int32
 	groupUngroup      bool
 
-	autoUpdateOn  bool
-	autoUpdateOff bool
-
 	metricsTime string
 
 	connectPort     uint
@@ -119,7 +116,6 @@ func init() {
 	containerCmd.AddCommand(containerStartCmd)
 	containerCmd.AddCommand(containerStopCmd)
 	containerCmd.AddCommand(containerRelaunchCmd)
-	containerCmd.AddCommand(containerAutoUpdateCmd)
 	containerCmd.AddCommand(containerMetricsCmd)
 	containerCmd.AddCommand(containerHostsCmd)
 	containerCmd.AddCommand(containerGroupCmd)
@@ -153,7 +149,6 @@ func init() {
 	addDebugSelector(containerStartCmd)
 	addDebugSelector(containerStopCmd)
 	addDebugSelector(containerRelaunchCmd)
-	addDebugSelector(containerAutoUpdateCmd)
 	addDebugSelector(containerMetricsCmd)
 	addDebugSelector(containerGroupCmd)
 	addDebugSelector(containerUpdateStatusCmd)
@@ -178,9 +173,6 @@ func init() {
 	containerRelaunchCmd.Flags().StringVar(&relaunchStaging, "staging", "", "Override staging mode (true/false)")
 	containerRelaunchCmd.Flags().StringVar(&relaunchCustomDomain, "custom-domain", "", "Override custom domain (empty string clears it)")
 	containerRelaunchCmd.Flags().StringVar(&relaunchHost, "host", "", "Move failed container to a different host")
-
-	containerAutoUpdateCmd.Flags().BoolVar(&autoUpdateOn, "on", false, "Enable auto-update")
-	containerAutoUpdateCmd.Flags().BoolVar(&autoUpdateOff, "off", false, "Disable auto-update")
 
 	containerMetricsCmd.Flags().StringVar(&metricsTime, "time", "24h", "Time window (e.g. 1h, 24h, 7d)")
 
@@ -443,35 +435,6 @@ var containerRelaunchCmd = &cobra.Command{
 			return err
 		}
 		return renderContainer(updated)
-	},
-}
-
-var containerAutoUpdateCmd = &cobra.Command{
-	Use:   "auto-update [id|name]",
-	Short: "Toggle auto-update for the container's repository deployment",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if autoUpdateOn == autoUpdateOff {
-			return fmt.Errorf("specify exactly one of --on or --off")
-		}
-		client, err := authedClient()
-		if err != nil {
-			return err
-		}
-		c, err := resolveContainer(client, args[0])
-		if err != nil {
-			return err
-		}
-		deployment, err := resolveDeploymentForContainer(client, *c)
-		if err != nil {
-			return err
-		}
-		updated, err := setDeploymentAutoUpdate(client, *deployment, autoUpdateOn)
-		if err != nil {
-			return err
-		}
-		fmt.Printf("auto_update=%s on %s\n", updated.AutoUpdate, updated.Repo)
-		return nil
 	},
 }
 

--- a/container.go
+++ b/container.go
@@ -18,37 +18,34 @@ import (
 // the fields the CLI actually displays or forwards; everything else stays in
 // RawMessage form so updates to the API don't break decoding here.
 type containerView struct {
-	ID                 string            `json:"id"`
-	Name               string            `json:"name"`
-	Repo               string            `json:"repo"`
-	Status             string            `json:"status"`
-	CurrentTag         string            `json:"current_tag"`
-	Domain             string            `json:"domain"`
-	InternalDomain     string            `json:"internal_domain"`
-	HostName           string            `json:"host_name"`
-	HostGpuType        string            `json:"host_gpu_type"`
-	HostCpuType        string            `json:"host_cpu_type"`
-	CPUs               int               `json:"cpus"`
-	GPUs               int               `json:"gpus"`
-	MemoryMB           int               `json:"memory_mb"`
-	Variables          json.RawMessage   `json:"variables"`
-	Secrets            []string          `json:"secrets"`
-	SSHKeys            []string          `json:"ssh_keys"`
-	Debug              bool              `json:"debug"`
-	Staging            bool              `json:"staging"`
-	DisableCCMode      bool              `json:"disable_cc_mode"`
-	GithubAppConnected bool              `json:"github_app_connected"`
-	AutoUpdate         bool              `json:"auto_update"`
-	GroupName          *string           `json:"group_name"`
-	GroupOrder         int               `json:"group_order"`
-	DisplayOrder       int               `json:"display_order"`
-	UpdateTag          string            `json:"update_tag"`
-	UpdateStatus       string            `json:"update_status"`
-	UpdateType         string            `json:"update_type"`
-	ErrorMessage       string            `json:"error_message"`
-	CreatedAt          string            `json:"created_at"`
-	UpdatedAt          string            `json:"updated_at"`
-	SSHPort            int               `json:"ssh_port"`
+	ID                 string          `json:"id"`
+	Name               string          `json:"name"`
+	Repo               string          `json:"repo"`
+	DeploymentID       string          `json:"deployment_id"`
+	Status             string          `json:"status"`
+	CurrentTag         string          `json:"current_tag"`
+	Domain             string          `json:"domain"`
+	InternalDomain     string          `json:"internal_domain"`
+	HostName           string          `json:"host_name"`
+	HostGpuType        string          `json:"host_gpu_type"`
+	HostCpuType        string          `json:"host_cpu_type"`
+	CPUs               int             `json:"cpus"`
+	GPUs               int             `json:"gpus"`
+	MemoryMB           int             `json:"memory_mb"`
+	Variables          json.RawMessage `json:"variables"`
+	Secrets            []string        `json:"secrets"`
+	SSHKeys            []string        `json:"ssh_keys"`
+	Debug              bool            `json:"debug"`
+	Staging            bool            `json:"staging"`
+	DisableCCMode      bool            `json:"disable_cc_mode"`
+	GithubAppConnected bool            `json:"github_app_connected"`
+	UpdateTag          string          `json:"update_tag"`
+	UpdateStatus       string          `json:"update_status"`
+	UpdateType         string          `json:"update_type"`
+	ErrorMessage       string          `json:"error_message"`
+	CreatedAt          string          `json:"created_at"`
+	UpdatedAt          string          `json:"updated_at"`
+	SSHPort            int             `json:"ssh_port"`
 }
 
 type hostInfo struct {
@@ -147,7 +144,7 @@ func init() {
 	containerCreateCmd.Flags().StringArrayVar(&createSSHKeys, "ssh-key", nil, "Org SSH key name (debug only); may be repeated")
 	containerCreateCmd.Flags().StringVar(&createGroupName, "group-name", "", "Place the container into the named group on creation")
 	containerCreateCmd.Flags().Int32Var(&createGroupOrder, "group-order", 0, "Sort order of the group itself (requires --group-name)")
-	containerCreateCmd.Flags().Int32Var(&createDisplayOrder, "display-order", 0, "Sort order of this container within the group (requires --group-name)")
+	containerCreateCmd.Flags().Int32Var(&createDisplayOrder, "display-order", 0, "Sort order of this container within its repository deployment")
 	_ = containerCreateCmd.MarkFlagRequired("repo")
 	_ = containerCreateCmd.MarkFlagRequired("tag")
 
@@ -187,10 +184,10 @@ func init() {
 
 	containerMetricsCmd.Flags().StringVar(&metricsTime, "time", "24h", "Time window (e.g. 1h, 24h, 7d)")
 
-	containerGroupCmd.Flags().StringVar(&groupName, "name", "", "Group name to assign")
-	containerGroupCmd.Flags().BoolVar(&groupUngroup, "ungroup", false, "Remove the container from any group")
+	containerGroupCmd.Flags().StringVar(&groupName, "name", "", "Group name to assign to the repository deployment")
+	containerGroupCmd.Flags().BoolVar(&groupUngroup, "ungroup", false, "Remove the repository deployment from any group")
 	containerGroupCmd.Flags().Int32Var(&groupOrder, "group-order", 0, "Order of the group itself")
-	containerGroupCmd.Flags().Int32Var(&groupDisplayOrder, "display-order", 0, "Display order within the group")
+	containerGroupCmd.Flags().Int32Var(&groupDisplayOrder, "display-order", 0, "Display order of the repository deployment")
 
 	containerConnectCmd.Flags().UintVarP(&connectPort, "port", "p", 8080, "Local port for the verified proxy")
 	containerConnectCmd.Flags().StringVarP(&connectBindAddr, "bind", "b", "127.0.0.1", "Address to bind to")
@@ -277,8 +274,8 @@ var containerCreateCmd = &cobra.Command{
 			}
 		}
 
-		if createGroupName == "" && (cmd.Flags().Changed("group-order") || cmd.Flags().Changed("display-order")) {
-			return fmt.Errorf("--group-order and --display-order require --group-name")
+		if createGroupName == "" && cmd.Flags().Changed("group-order") {
+			return fmt.Errorf("--group-order requires --group-name")
 		}
 
 		body := map[string]any{
@@ -289,6 +286,8 @@ var containerCreateCmd = &cobra.Command{
 		if createGroupName != "" {
 			body["group_name"] = createGroupName
 			body["group_order"] = createGroupOrder
+			body["display_order"] = createDisplayOrder
+		} else if cmd.Flags().Changed("display-order") {
 			body["display_order"] = createDisplayOrder
 		}
 		if len(vars) > 0 {
@@ -322,6 +321,22 @@ var containerCreateCmd = &cobra.Command{
 		var created containerView
 		if _, err := client.do("POST", "/api/containers", nil, body, &created); err != nil {
 			return err
+		}
+		if createGroupName != "" {
+			deployment, err := resolveDeploymentForContainer(client, created)
+			if err != nil {
+				return fmt.Errorf("container created, but deployment group could not be set: %w", err)
+			}
+			groupName := createGroupName
+			if _, err := moveDeploymentToGroup(
+				client,
+				deployment.ID,
+				&groupName,
+				createGroupOrder,
+				deployment.DisplayOrder,
+			); err != nil {
+				return fmt.Errorf("container created, but deployment group could not be set: %w", err)
+			}
 		}
 		return renderContainer(created)
 	},
@@ -433,7 +448,7 @@ var containerRelaunchCmd = &cobra.Command{
 
 var containerAutoUpdateCmd = &cobra.Command{
 	Use:   "auto-update [id|name]",
-	Short: "Toggle auto-update for a GitHub-connected container",
+	Short: "Toggle auto-update for the container's repository deployment",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if autoUpdateOn == autoUpdateOff {
@@ -447,12 +462,15 @@ var containerAutoUpdateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		body := map[string]any{"auto_update": autoUpdateOn}
-		var updated containerView
-		if _, err := client.do("POST", pathf("/api/containers/%s/auto-update", c.ID), nil, body, &updated); err != nil {
+		deployment, err := resolveDeploymentForContainer(client, *c)
+		if err != nil {
 			return err
 		}
-		fmt.Printf("auto_update=%v on %s\n", updated.AutoUpdate, updated.Name)
+		updated, err := setDeploymentAutoUpdate(client, *deployment, autoUpdateOn)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("auto_update=%s on %s\n", updated.AutoUpdate, updated.Repo)
 		return nil
 	},
 }
@@ -512,7 +530,7 @@ var containerHostsCmd = &cobra.Command{
 
 var containerGroupCmd = &cobra.Command{
 	Use:   "group [id|name]",
-	Short: "Move a container into (or out of) a group",
+	Short: "Move the container's repository deployment into or out of a group",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !groupUngroup && groupName == "" {
@@ -529,33 +547,35 @@ var containerGroupCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		// The controlplane has no partial-update semantics for these fields;
-		// any value sent (including 0) is written verbatim. Preserve the
-		// container's current order when the user didn't pass the flag, so
-		// `container group my-app --name foo` doesn't silently reset
-		// existing positions.
-		groupOrderToSend := int32(c.GroupOrder)
+		deployment, err := resolveDeploymentForContainer(client, *c)
+		if err != nil {
+			return err
+		}
+		groupOrderToSend := deployment.GroupOrder
 		if cmd.Flags().Changed("group-order") {
 			groupOrderToSend = groupOrder
 		}
-		displayOrderToSend := int32(c.DisplayOrder)
+		displayOrderToSend := deployment.DisplayOrder
 		if cmd.Flags().Changed("display-order") {
 			displayOrderToSend = groupDisplayOrder
 		}
-		body := map[string]any{
-			"group_order":   groupOrderToSend,
-			"display_order": displayOrderToSend,
-		}
+		var groupNameToSend *string
 		if groupUngroup {
-			body["group_name"] = nil
+			groupNameToSend = nil
 		} else {
-			body["group_name"] = groupName
+			groupNameToSend = &groupName
 		}
-		var updated containerView
-		if _, err := client.do("PUT", pathf("/api/containers/%s/group", c.ID), nil, body, &updated); err != nil {
+		updated, err := moveDeploymentToGroup(
+			client,
+			deployment.ID,
+			groupNameToSend,
+			groupOrderToSend,
+			displayOrderToSend,
+		)
+		if err != nil {
 			return err
 		}
-		return renderContainer(updated)
+		return renderDeployment(updated)
 	},
 }
 
@@ -876,6 +896,9 @@ func renderContainer(c containerView) error {
 	fmt.Printf("Name:         %s\n", c.Name)
 	fmt.Printf("Status:       %s\n", c.Status)
 	fmt.Printf("Repo:         %s@%s\n", c.Repo, c.CurrentTag)
+	if c.DeploymentID != "" {
+		fmt.Printf("Deployment:   %s\n", c.DeploymentID)
+	}
 	if c.Domain != "" {
 		fmt.Printf("Domain:       %s\n", c.Domain)
 	}
@@ -894,9 +917,6 @@ func renderContainer(c containerView) error {
 	}
 	if c.DisableCCMode {
 		fmt.Printf("Mode:         non-cc (confidential computing disabled)\n")
-	}
-	if c.AutoUpdate {
-		fmt.Printf("Auto-update:  enabled\n")
 	}
 	if c.SSHPort > 0 {
 		fmt.Printf("SSH port:     %d\n", c.SSHPort)
@@ -1005,4 +1025,3 @@ func prettyJSON(raw json.RawMessage) []byte {
 	}
 	return out
 }
-

--- a/deployment.go
+++ b/deployment.go
@@ -1,0 +1,430 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	deploymentAutoUpdateOff    = "off"
+	deploymentAutoUpdateLatest = "latest"
+
+	deploymentInstanceStatusSkipped = "skipped"
+	deploymentInstanceStatusFailed  = "failed"
+)
+
+type deploymentView struct {
+	ID             string  `json:"id"`
+	Repo           string  `json:"repo"`
+	GroupName      *string `json:"group_name"`
+	GroupOrder     int32   `json:"group_order"`
+	DisplayOrder   int32   `json:"display_order"`
+	AutoUpdate     string  `json:"auto_update"`
+	DefaultStaging bool    `json:"default_staging"`
+	CreatedAt      string  `json:"created_at"`
+	UpdatedAt      string  `json:"updated_at"`
+	InstanceCount  int32   `json:"instance_count"`
+	ReadyCount     int32   `json:"ready_count"`
+	FailedCount    int32   `json:"failed_count"`
+	StoppedCount   int32   `json:"stopped_count"`
+	DeployingCount int32   `json:"deploying_count"`
+}
+
+type deploymentInstanceResult struct {
+	ContainerID string         `json:"container_id"`
+	Name        string         `json:"name"`
+	Status      string         `json:"status"`
+	Error       string         `json:"error,omitempty"`
+	Container   *containerView `json:"container,omitempty"`
+}
+
+type deploymentUpdateResponse struct {
+	Results []deploymentInstanceResult `json:"results"`
+}
+
+var (
+	deploymentSettingsAutoUpdate     string
+	deploymentSettingsDefaultStaging string
+
+	deploymentGroupName         string
+	deploymentGroupOrder        int32
+	deploymentGroupDisplayOrder int32
+	deploymentGroupUngroup      bool
+
+	deploymentUpdateTag         string
+	deploymentUpdateStaging     string
+	deploymentUpdateInstanceIDs []string
+)
+
+func init() {
+	rootCmd.AddCommand(deploymentCmd)
+	deploymentCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "table", "Output format: table or json")
+	deploymentCmd.AddCommand(deploymentListCmd)
+	deploymentCmd.AddCommand(deploymentGetCmd)
+	deploymentCmd.AddCommand(deploymentSettingsCmd)
+	deploymentCmd.AddCommand(deploymentGroupCmd)
+	deploymentCmd.AddCommand(deploymentUpdateCmd)
+
+	deploymentSettingsCmd.Flags().StringVar(
+		&deploymentSettingsAutoUpdate,
+		"auto-update",
+		"",
+		"Auto-update policy: off or latest",
+	)
+	deploymentSettingsCmd.Flags().StringVar(
+		&deploymentSettingsDefaultStaging,
+		"default-staging",
+		"",
+		"Default staging mode for deployment updates (true/false)",
+	)
+
+	deploymentGroupCmd.Flags().StringVar(&deploymentGroupName, "name", "", "Group name to assign")
+	deploymentGroupCmd.Flags().BoolVar(&deploymentGroupUngroup, "ungroup", false, "Remove the deployment from any group")
+	deploymentGroupCmd.Flags().Int32Var(&deploymentGroupOrder, "group-order", 0, "Order of the group itself")
+	deploymentGroupCmd.Flags().Int32Var(&deploymentGroupDisplayOrder, "display-order", 0, "Display order of the deployment")
+
+	deploymentUpdateCmd.Flags().StringVar(&deploymentUpdateTag, "tag", "", "Repository release tag to deploy")
+	deploymentUpdateCmd.Flags().StringVar(&deploymentUpdateStaging, "staging", "", "Override staging mode (true/false)")
+	deploymentUpdateCmd.Flags().StringArrayVar(
+		&deploymentUpdateInstanceIDs,
+		"instance",
+		nil,
+		"Container instance ID to update; may be repeated (default: all instances)",
+	)
+	_ = deploymentUpdateCmd.MarkFlagRequired("tag")
+
+	silenceUsageRecursive(deploymentCmd)
+}
+
+var deploymentCmd = &cobra.Command{
+	Use:          "deployment",
+	Aliases:      []string{"deployments", "dep"},
+	Short:        "Manage repository deployments",
+	SilenceUsage: true,
+}
+
+var deploymentListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List repository deployments in the current organization",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		deployments, err := listDeployments(client)
+		if err != nil {
+			return err
+		}
+		return renderDeployments(deployments)
+	},
+}
+
+var deploymentGetCmd = &cobra.Command{
+	Use:   "get [id|owner/repo]",
+	Short: "Show a repository deployment",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		deployment, err := resolveDeployment(client, args[0])
+		if err != nil {
+			return err
+		}
+		return renderDeployment(*deployment)
+	},
+}
+
+var deploymentSettingsCmd = &cobra.Command{
+	Use:     "settings [id|owner/repo]",
+	Aliases: []string{"set"},
+	Short:   "Update repository deployment settings",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		body := map[string]any{}
+		if deploymentSettingsAutoUpdate != "" {
+			policy := strings.ToLower(strings.TrimSpace(deploymentSettingsAutoUpdate))
+			if policy != deploymentAutoUpdateOff && policy != deploymentAutoUpdateLatest {
+				return fmt.Errorf("--auto-update must be %q or %q", deploymentAutoUpdateOff, deploymentAutoUpdateLatest)
+			}
+			body["auto_update"] = policy
+		}
+		if deploymentSettingsDefaultStaging != "" {
+			staging, err := parseTriBool(deploymentSettingsDefaultStaging)
+			if err != nil {
+				return fmt.Errorf("--default-staging: %w", err)
+			}
+			body["default_staging"] = staging
+		}
+		if len(body) == 0 {
+			return fmt.Errorf("specify --auto-update or --default-staging")
+		}
+
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		deployment, err := resolveDeployment(client, args[0])
+		if err != nil {
+			return err
+		}
+		updated, err := patchDeployment(client, deployment.ID, body)
+		if err != nil {
+			return err
+		}
+		updated = preserveDeploymentCounts(updated, *deployment)
+		return renderDeployment(updated)
+	},
+}
+
+var deploymentGroupCmd = &cobra.Command{
+	Use:   "group [id|owner/repo]",
+	Short: "Move a repository deployment into or out of a group",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !deploymentGroupUngroup && deploymentGroupName == "" {
+			return fmt.Errorf("specify --name <group> or --ungroup")
+		}
+		if deploymentGroupUngroup && deploymentGroupName != "" {
+			return fmt.Errorf("--name and --ungroup are mutually exclusive")
+		}
+
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		deployment, err := resolveDeployment(client, args[0])
+		if err != nil {
+			return err
+		}
+
+		groupOrder := deployment.GroupOrder
+		if cmd.Flags().Changed("group-order") {
+			groupOrder = deploymentGroupOrder
+		}
+		displayOrder := deployment.DisplayOrder
+		if cmd.Flags().Changed("display-order") {
+			displayOrder = deploymentGroupDisplayOrder
+		}
+		var groupName *string
+		if !deploymentGroupUngroup {
+			groupName = &deploymentGroupName
+		}
+		updated, err := moveDeploymentToGroup(client, deployment.ID, groupName, groupOrder, displayOrder)
+		if err != nil {
+			return err
+		}
+		updated = preserveDeploymentCounts(updated, *deployment)
+		return renderDeployment(updated)
+	},
+}
+
+var deploymentUpdateCmd = &cobra.Command{
+	Use:   "update [id|owner/repo]",
+	Short: "Update all or selected instances of a repository deployment",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		deployment, err := resolveDeployment(client, args[0])
+		if err != nil {
+			return err
+		}
+
+		body := map[string]any{"tag": deploymentUpdateTag}
+		if cmd.Flags().Changed("staging") {
+			staging, err := parseTriBool(deploymentUpdateStaging)
+			if err != nil {
+				return fmt.Errorf("--staging: %w", err)
+			}
+			body["staging"] = staging
+		}
+		if len(deploymentUpdateInstanceIDs) > 0 {
+			body["instance_ids"] = deploymentUpdateInstanceIDs
+		}
+
+		response, err := updateDeploymentInstances(client, deployment.ID, body)
+		if err != nil {
+			return err
+		}
+		return renderDeploymentUpdateResults(response.Results)
+	},
+}
+
+func listDeployments(client *cpClient) ([]deploymentView, error) {
+	var deployments []deploymentView
+	if _, err := client.do("GET", "/api/deployments", nil, nil, &deployments); err != nil {
+		return nil, err
+	}
+	return deployments, nil
+}
+
+func resolveDeployment(client *cpClient, identifier string) (*deploymentView, error) {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return nil, fmt.Errorf("deployment identifier is empty")
+	}
+
+	deployments, err := listDeployments(client)
+	if err != nil {
+		return nil, err
+	}
+	for i := range deployments {
+		if deployments[i].ID == identifier || deployments[i].Repo == identifier {
+			return &deployments[i], nil
+		}
+	}
+	return nil, fmt.Errorf("no deployment matching %q (use the deployment ID, owner/repo, or `tinfoil deployment list`)", identifier)
+}
+
+func resolveDeploymentForContainer(client *cpClient, container containerView) (*deploymentView, error) {
+	if container.DeploymentID != "" {
+		return resolveDeployment(client, container.DeploymentID)
+	}
+	if container.Repo != "" {
+		return resolveDeployment(client, container.Repo)
+	}
+	return nil, fmt.Errorf("container %s is not linked to a repository deployment", container.Name)
+}
+
+func patchDeployment(client *cpClient, deploymentID string, body map[string]any) (deploymentView, error) {
+	var updated deploymentView
+	if _, err := client.do("PATCH", pathf("/api/deployments/%s", deploymentID), nil, body, &updated); err != nil {
+		return deploymentView{}, err
+	}
+	return updated, nil
+}
+
+func setDeploymentAutoUpdate(client *cpClient, deployment deploymentView, enabled bool) (deploymentView, error) {
+	policy := deploymentAutoUpdateOff
+	if enabled {
+		policy = deploymentAutoUpdateLatest
+	}
+	return patchDeployment(client, deployment.ID, map[string]any{"auto_update": policy})
+}
+
+func moveDeploymentToGroup(
+	client *cpClient,
+	deploymentID string,
+	groupName *string,
+	groupOrder, displayOrder int32,
+) (deploymentView, error) {
+	body := map[string]any{
+		"group_name":    groupName,
+		"group_order":   groupOrder,
+		"display_order": displayOrder,
+	}
+	var updated deploymentView
+	if _, err := client.do("PUT", pathf("/api/deployments/%s/group", deploymentID), nil, body, &updated); err != nil {
+		return deploymentView{}, err
+	}
+	return updated, nil
+}
+
+func updateDeploymentInstances(client *cpClient, deploymentID string, body map[string]any) (deploymentUpdateResponse, error) {
+	var response deploymentUpdateResponse
+	if _, err := client.do("POST", pathf("/api/deployments/%s/update", deploymentID), nil, body, &response); err != nil {
+		return deploymentUpdateResponse{}, err
+	}
+	return response, nil
+}
+
+func preserveDeploymentCounts(updated, current deploymentView) deploymentView {
+	updated.InstanceCount = current.InstanceCount
+	updated.ReadyCount = current.ReadyCount
+	updated.FailedCount = current.FailedCount
+	updated.StoppedCount = current.StoppedCount
+	updated.DeployingCount = current.DeployingCount
+	return updated
+}
+
+func renderDeployment(deployment deploymentView) error {
+	if outputFormat == "json" {
+		return printJSON(deployment)
+	}
+	fmt.Printf("ID:              %s\n", deployment.ID)
+	fmt.Printf("Repository:      %s\n", deployment.Repo)
+	fmt.Printf("Instances:       %d\n", deployment.InstanceCount)
+	fmt.Printf("Ready:           %d\n", deployment.ReadyCount)
+	fmt.Printf("Deploying:       %d\n", deployment.DeployingCount)
+	fmt.Printf("Failed:          %d\n", deployment.FailedCount)
+	fmt.Printf("Stopped:         %d\n", deployment.StoppedCount)
+	fmt.Printf("Auto-update:     %s\n", deployment.AutoUpdate)
+	fmt.Printf("Default staging: %v\n", deployment.DefaultStaging)
+	if deployment.GroupName != nil {
+		fmt.Printf("Group:           %s\n", *deployment.GroupName)
+	}
+	return nil
+}
+
+func renderDeployments(deployments []deploymentView) error {
+	if outputFormat == "json" {
+		return printJSON(deployments)
+	}
+	if len(deployments) == 0 {
+		fmt.Println("No deployments.")
+		return nil
+	}
+	fmt.Printf("%-36s  %-9s  %-7s  %-9s  %-6s  %-12s  %s\n",
+		"REPOSITORY", "INSTANCES", "READY", "DEPLOYING", "FAILED", "AUTO-UPDATE", "GROUP",
+	)
+	for _, deployment := range deployments {
+		group := "-"
+		if deployment.GroupName != nil {
+			group = *deployment.GroupName
+		}
+		fmt.Printf("%-36s  %-9d  %-7d  %-9d  %-6d  %-12s  %s\n",
+			truncate(deployment.Repo, 36),
+			deployment.InstanceCount,
+			deployment.ReadyCount,
+			deployment.DeployingCount,
+			deployment.FailedCount,
+			deployment.AutoUpdate,
+			group,
+		)
+	}
+	return nil
+}
+
+func renderDeploymentUpdateResults(results []deploymentInstanceResult) error {
+	if outputFormat == "json" {
+		if err := printJSON(deploymentUpdateResponse{Results: results}); err != nil {
+			return err
+		}
+	}
+	if len(results) == 0 {
+		if outputFormat != "json" {
+			fmt.Println("No deployment instances were selected.")
+		}
+		return nil
+	}
+	if outputFormat != "json" {
+		fmt.Printf("%-24s  %-10s  %s\n", "NAME", "STATUS", "DETAIL")
+	}
+	failed, skipped := 0, 0
+	for _, result := range results {
+		if outputFormat != "json" {
+			detail := result.Error
+			if detail == "" {
+				detail = result.ContainerID
+			}
+			fmt.Printf("%-24s  %-10s  %s\n", truncate(result.Name, 24), result.Status, detail)
+		}
+		switch result.Status {
+		case deploymentInstanceStatusFailed:
+			failed++
+		case deploymentInstanceStatusSkipped:
+			skipped++
+		}
+	}
+	if failed > 0 || skipped > 0 {
+		return fmt.Errorf("deployment update incomplete: %d failed, %d skipped", failed, skipped)
+	}
+	return nil
+}

--- a/deployment.go
+++ b/deployment.go
@@ -8,9 +8,6 @@ import (
 )
 
 const (
-	deploymentAutoUpdateOff    = "off"
-	deploymentAutoUpdateLatest = "latest"
-
 	deploymentInstanceStatusSkipped = "skipped"
 	deploymentInstanceStatusFailed  = "failed"
 )
@@ -21,7 +18,6 @@ type deploymentView struct {
 	GroupName      *string `json:"group_name"`
 	GroupOrder     int32   `json:"group_order"`
 	DisplayOrder   int32   `json:"display_order"`
-	AutoUpdate     string  `json:"auto_update"`
 	DefaultStaging bool    `json:"default_staging"`
 	CreatedAt      string  `json:"created_at"`
 	UpdatedAt      string  `json:"updated_at"`
@@ -45,7 +41,6 @@ type deploymentUpdateResponse struct {
 }
 
 var (
-	deploymentSettingsAutoUpdate     string
 	deploymentSettingsDefaultStaging string
 
 	deploymentGroupName         string
@@ -67,12 +62,6 @@ func init() {
 	deploymentCmd.AddCommand(deploymentGroupCmd)
 	deploymentCmd.AddCommand(deploymentUpdateCmd)
 
-	deploymentSettingsCmd.Flags().StringVar(
-		&deploymentSettingsAutoUpdate,
-		"auto-update",
-		"",
-		"Auto-update policy: off or latest",
-	)
 	deploymentSettingsCmd.Flags().StringVar(
 		&deploymentSettingsDefaultStaging,
 		"default-staging",
@@ -146,13 +135,6 @@ var deploymentSettingsCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		body := map[string]any{}
-		if deploymentSettingsAutoUpdate != "" {
-			policy := strings.ToLower(strings.TrimSpace(deploymentSettingsAutoUpdate))
-			if policy != deploymentAutoUpdateOff && policy != deploymentAutoUpdateLatest {
-				return fmt.Errorf("--auto-update must be %q or %q", deploymentAutoUpdateOff, deploymentAutoUpdateLatest)
-			}
-			body["auto_update"] = policy
-		}
 		if deploymentSettingsDefaultStaging != "" {
 			staging, err := parseTriBool(deploymentSettingsDefaultStaging)
 			if err != nil {
@@ -161,7 +143,7 @@ var deploymentSettingsCmd = &cobra.Command{
 			body["default_staging"] = staging
 		}
 		if len(body) == 0 {
-			return fmt.Errorf("specify --auto-update or --default-staging")
+			return fmt.Errorf("specify --default-staging")
 		}
 
 		client, err := authedClient()
@@ -301,14 +283,6 @@ func patchDeployment(client *cpClient, deploymentID string, body map[string]any)
 	return updated, nil
 }
 
-func setDeploymentAutoUpdate(client *cpClient, deployment deploymentView, enabled bool) (deploymentView, error) {
-	policy := deploymentAutoUpdateOff
-	if enabled {
-		policy = deploymentAutoUpdateLatest
-	}
-	return patchDeployment(client, deployment.ID, map[string]any{"auto_update": policy})
-}
-
 func moveDeploymentToGroup(
 	client *cpClient,
 	deploymentID string,
@@ -355,7 +329,6 @@ func renderDeployment(deployment deploymentView) error {
 	fmt.Printf("Deploying:       %d\n", deployment.DeployingCount)
 	fmt.Printf("Failed:          %d\n", deployment.FailedCount)
 	fmt.Printf("Stopped:         %d\n", deployment.StoppedCount)
-	fmt.Printf("Auto-update:     %s\n", deployment.AutoUpdate)
 	fmt.Printf("Default staging: %v\n", deployment.DefaultStaging)
 	if deployment.GroupName != nil {
 		fmt.Printf("Group:           %s\n", *deployment.GroupName)
@@ -371,21 +344,20 @@ func renderDeployments(deployments []deploymentView) error {
 		fmt.Println("No deployments.")
 		return nil
 	}
-	fmt.Printf("%-36s  %-9s  %-7s  %-9s  %-6s  %-12s  %s\n",
-		"REPOSITORY", "INSTANCES", "READY", "DEPLOYING", "FAILED", "AUTO-UPDATE", "GROUP",
+	fmt.Printf("%-36s  %-9s  %-7s  %-9s  %-6s  %s\n",
+		"REPOSITORY", "INSTANCES", "READY", "DEPLOYING", "FAILED", "GROUP",
 	)
 	for _, deployment := range deployments {
 		group := "-"
 		if deployment.GroupName != nil {
 			group = *deployment.GroupName
 		}
-		fmt.Printf("%-36s  %-9d  %-7d  %-9d  %-6d  %-12s  %s\n",
+		fmt.Printf("%-36s  %-9d  %-7d  %-9d  %-6d  %s\n",
 			truncate(deployment.Repo, 36),
 			deployment.InstanceCount,
 			deployment.ReadyCount,
 			deployment.DeployingCount,
 			deployment.FailedCount,
-			deployment.AutoUpdate,
 			group,
 		)
 	}

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveDeploymentMatchesIDAndRepository(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/deployments" {
+			t.Fatalf("request = %s %s, want GET /api/deployments", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[{"id":"deployment-1","repo":"acme/app","auto_update":"off"}]`)
+	}))
+	defer server.Close()
+
+	client := &cpClient{baseURL: server.URL, http: server.Client()}
+	for _, identifier := range []string{"deployment-1", "acme/app"} {
+		deployment, err := resolveDeployment(client, identifier)
+		if err != nil {
+			t.Fatalf("resolveDeployment(%q): %v", identifier, err)
+		}
+		if deployment.ID != "deployment-1" {
+			t.Fatalf("deployment ID = %q", deployment.ID)
+		}
+	}
+}
+
+func TestContainerAutoUpdateUsesDeploymentSettings(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/containers":
+			_, _ = io.WriteString(w, `[{"id":"container-1","name":"app-1","repo":"acme/app","deployment_id":"deployment-1"}]`)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/deployments":
+			_, _ = io.WriteString(w, `[{"id":"deployment-1","repo":"acme/app","auto_update":"off"}]`)
+		case r.Method == http.MethodPatch && r.URL.Path == "/api/deployments/deployment-1":
+			var body struct {
+				AutoUpdate string `json:"auto_update"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body.AutoUpdate != deploymentAutoUpdateLatest {
+				t.Fatalf("auto_update = %q, want %q", body.AutoUpdate, deploymentAutoUpdateLatest)
+			}
+			_, _ = io.WriteString(w, `{"id":"deployment-1","repo":"acme/app","auto_update":"latest"}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configureDeploymentCommandTest(t, server.URL)
+	autoUpdateOn = true
+
+	if err := containerAutoUpdateCmd.RunE(containerAutoUpdateCmd, []string{"app-1"}); err != nil {
+		t.Fatalf("run auto-update: %v", err)
+	}
+}
+
+func TestContainerGroupMovesRepositoryDeployment(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/containers":
+			_, _ = io.WriteString(w, `[{"id":"container-1","name":"app-1","repo":"acme/app","deployment_id":"deployment-1"}]`)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/deployments":
+			_, _ = io.WriteString(w, `[{"id":"deployment-1","repo":"acme/app","group_order":4,"display_order":7,"auto_update":"off"}]`)
+		case r.Method == http.MethodPut && r.URL.Path == "/api/deployments/deployment-1/group":
+			var body struct {
+				GroupName    *string `json:"group_name"`
+				GroupOrder   int32   `json:"group_order"`
+				DisplayOrder int32   `json:"display_order"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body.GroupName == nil || *body.GroupName != "production" {
+				t.Fatalf("group_name = %v", body.GroupName)
+			}
+			if body.GroupOrder != 4 || body.DisplayOrder != 7 {
+				t.Fatalf("orders = (%d, %d), want (4, 7)", body.GroupOrder, body.DisplayOrder)
+			}
+			_, _ = io.WriteString(w, `{"id":"deployment-1","repo":"acme/app","group_name":"production","group_order":4,"display_order":7,"auto_update":"off"}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configureDeploymentCommandTest(t, server.URL)
+	groupName = "production"
+
+	if err := containerGroupCmd.RunE(containerGroupCmd, []string{"app-1"}); err != nil {
+		t.Fatalf("run group: %v", err)
+	}
+}
+
+func TestContainerCreateSetsDeploymentGroup(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/containers":
+			var body struct {
+				Repo         string `json:"repo"`
+				GroupName    string `json:"group_name"`
+				GroupOrder   int32  `json:"group_order"`
+				DisplayOrder int32  `json:"display_order"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body.Repo != "acme/app" || body.GroupName != "production" {
+				t.Fatalf("create body = %+v", body)
+			}
+			if body.GroupOrder != 4 || body.DisplayOrder != 2 {
+				t.Fatalf("orders = (%d, %d), want (4, 2)", body.GroupOrder, body.DisplayOrder)
+			}
+			_, _ = io.WriteString(w, `{"id":"container-1","name":"app-1","repo":"acme/app","deployment_id":"deployment-1"}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/deployments":
+			_, _ = io.WriteString(w, `[{"id":"deployment-1","repo":"acme/app","display_order":7,"auto_update":"off"}]`)
+		case r.Method == http.MethodPut && r.URL.Path == "/api/deployments/deployment-1/group":
+			var body struct {
+				GroupName    *string `json:"group_name"`
+				GroupOrder   int32   `json:"group_order"`
+				DisplayOrder int32   `json:"display_order"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body.GroupName == nil || *body.GroupName != "production" {
+				t.Fatalf("group_name = %v", body.GroupName)
+			}
+			if body.GroupOrder != 4 || body.DisplayOrder != 7 {
+				t.Fatalf("orders = (%d, %d), want (4, 7)", body.GroupOrder, body.DisplayOrder)
+			}
+			_, _ = io.WriteString(w, `{"id":"deployment-1","repo":"acme/app","group_name":"production","group_order":4,"display_order":7,"auto_update":"off"}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configureDeploymentCommandTest(t, server.URL)
+	createRepo = "acme/app"
+	createTag = "v1.2.3"
+	createGroupName = "production"
+	createGroupOrder = 4
+	createDisplayOrder = 2
+
+	if err := containerCreateCmd.RunE(containerCreateCmd, []string{"app-1"}); err != nil {
+		t.Fatalf("run create: %v", err)
+	}
+}
+
+func TestDeploymentUpdateUsesDeploymentEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/deployments":
+			_, _ = io.WriteString(w, `[{"id":"deployment-1","repo":"acme/app","auto_update":"off"}]`)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/deployments/deployment-1/update":
+			var body struct {
+				Tag         string   `json:"tag"`
+				InstanceIDs []string `json:"instance_ids"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body.Tag != "v1.2.3" {
+				t.Fatalf("tag = %q", body.Tag)
+			}
+			if len(body.InstanceIDs) != 1 || body.InstanceIDs[0] != "container-1" {
+				t.Fatalf("instance_ids = %v", body.InstanceIDs)
+			}
+			_, _ = io.WriteString(w, `{"results":[{"container_id":"container-1","name":"app-1","status":"updating"}]}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configureDeploymentCommandTest(t, server.URL)
+	deploymentUpdateTag = "v1.2.3"
+	deploymentUpdateInstanceIDs = []string{"container-1"}
+
+	if err := deploymentUpdateCmd.RunE(deploymentUpdateCmd, []string{"acme/app"}); err != nil {
+		t.Fatalf("run deployment update: %v", err)
+	}
+}
+
+func TestDeploymentUpdateResultsFailForIncompleteUpdates(t *testing.T) {
+	previousOutput := outputFormat
+	t.Cleanup(func() {
+		outputFormat = previousOutput
+	})
+
+	results := []deploymentInstanceResult{
+		{Name: "app-1", Status: deploymentInstanceStatusFailed, Error: "host unavailable"},
+		{Name: "app-2", Status: deploymentInstanceStatusSkipped, Error: "update already in progress"},
+	}
+	for _, format := range []string{"table", "json"} {
+		t.Run(format, func(t *testing.T) {
+			outputFormat = format
+			if err := renderDeploymentUpdateResults(results); err == nil {
+				t.Fatal("expected incomplete deployment update error")
+			}
+		})
+	}
+}
+
+func configureDeploymentCommandTest(t *testing.T, serverURL string) {
+	t.Helper()
+	t.Setenv(envCPURL, serverURL)
+	t.Setenv(envAPIKey, "admin_test")
+	t.Setenv(envConfigPath, filepath.Join(t.TempDir(), "missing-config.json"))
+
+	previousOutput := outputFormat
+	previousAutoUpdateOn := autoUpdateOn
+	previousAutoUpdateOff := autoUpdateOff
+	previousGroupName := groupName
+	previousGroupUngroup := groupUngroup
+	previousGroupOrder := groupOrder
+	previousGroupDisplayOrder := groupDisplayOrder
+	previousCreateRepo := createRepo
+	previousCreateTag := createTag
+	previousCreateGroupName := createGroupName
+	previousCreateGroupOrder := createGroupOrder
+	previousCreateDisplayOrder := createDisplayOrder
+	previousUpdateTag := deploymentUpdateTag
+	previousUpdateStaging := deploymentUpdateStaging
+	previousUpdateInstanceIDs := deploymentUpdateInstanceIDs
+	previousUseDebugFilter := useDebugFilter
+
+	outputFormat = "json"
+	autoUpdateOn = false
+	autoUpdateOff = false
+	groupName = ""
+	groupUngroup = false
+	groupOrder = 0
+	groupDisplayOrder = 0
+	createRepo = ""
+	createTag = ""
+	createGroupName = ""
+	createGroupOrder = 0
+	createDisplayOrder = 0
+	deploymentUpdateTag = ""
+	deploymentUpdateStaging = ""
+	deploymentUpdateInstanceIDs = nil
+	useDebugFilter = false
+
+	t.Cleanup(func() {
+		outputFormat = previousOutput
+		autoUpdateOn = previousAutoUpdateOn
+		autoUpdateOff = previousAutoUpdateOff
+		groupName = previousGroupName
+		groupUngroup = previousGroupUngroup
+		groupOrder = previousGroupOrder
+		groupDisplayOrder = previousGroupDisplayOrder
+		createRepo = previousCreateRepo
+		createTag = previousCreateTag
+		createGroupName = previousCreateGroupName
+		createGroupOrder = previousCreateGroupOrder
+		createDisplayOrder = previousCreateDisplayOrder
+		deploymentUpdateTag = previousUpdateTag
+		deploymentUpdateStaging = previousUpdateStaging
+		deploymentUpdateInstanceIDs = previousUpdateInstanceIDs
+		useDebugFilter = previousUseDebugFilter
+	})
+}

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -114,59 +114,27 @@ func TestContainerGroupMovesRepositoryDeployment(t *testing.T) {
 	}
 }
 
-func TestContainerGroupFallsBackToLegacyEndpoint(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/containers":
-			_, _ = io.WriteString(w, `[{"id":"container-1","name":"app-1","repo":"acme/app","group_order":4,"display_order":7}]`)
-		case r.Method == http.MethodPut && r.URL.Path == "/api/containers/container-1/group":
-			var body struct {
-				GroupName    *string `json:"group_name"`
-				GroupOrder   int32   `json:"group_order"`
-				DisplayOrder int32   `json:"display_order"`
-			}
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("decode body: %v", err)
-			}
-			if body.GroupName == nil || *body.GroupName != "production" {
-				t.Fatalf("group_name = %v", body.GroupName)
-			}
-			if body.GroupOrder != 4 || body.DisplayOrder != 7 {
-				t.Fatalf("orders = (%d, %d), want (4, 7)", body.GroupOrder, body.DisplayOrder)
-			}
-			_, _ = io.WriteString(w, `{"id":"container-1","name":"app-1","repo":"acme/app","group_name":"production","group_order":4,"display_order":7}`)
-		default:
-			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
-		}
-	}))
-	defer server.Close()
-
-	configureDeploymentCommandTest(t, server.URL)
-	groupName = "production"
-
-	if err := containerGroupCmd.RunE(containerGroupCmd, []string{"app-1"}); err != nil {
-		t.Fatalf("run legacy group: %v", err)
-	}
-}
-
 func TestContainerCreateSetsDeploymentGroup(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/api/containers":
 			var body struct {
-				Repo         string `json:"repo"`
-				GroupName    string `json:"group_name"`
-				GroupOrder   int32  `json:"group_order"`
-				DisplayOrder int32  `json:"display_order"`
+				Repo         string  `json:"repo"`
+				GroupName    *string `json:"group_name"`
+				GroupOrder   *int32  `json:"group_order"`
+				DisplayOrder *int32  `json:"display_order"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatalf("decode body: %v", err)
 			}
-			if body.Repo != "acme/app" || body.GroupName != "production" {
+			if body.Repo != "acme/app" {
 				t.Fatalf("create body = %+v", body)
 			}
-			if body.GroupOrder != 4 || body.DisplayOrder != 2 {
-				t.Fatalf("orders = (%d, %d), want (4, 2)", body.GroupOrder, body.DisplayOrder)
+			if body.GroupName != nil || body.GroupOrder != nil {
+				t.Fatalf("legacy group fields were sent: %+v", body)
+			}
+			if body.DisplayOrder == nil || *body.DisplayOrder != 2 {
+				t.Fatalf("display_order = %v, want 2", body.DisplayOrder)
 			}
 			_, _ = io.WriteString(w, `{"id":"container-1","name":"app-1","repo":"acme/app","deployment_id":"deployment-1"}`)
 		case r.Method == http.MethodGet && r.URL.Path == "/api/deployments":
@@ -199,39 +167,15 @@ func TestContainerCreateSetsDeploymentGroup(t *testing.T) {
 	createGroupName = "production"
 	createGroupOrder = 4
 	createDisplayOrder = 2
+	displayOrderFlag := containerCreateCmd.Flags().Lookup("display-order")
+	previousDisplayOrderChanged := displayOrderFlag.Changed
+	displayOrderFlag.Changed = true
+	t.Cleanup(func() {
+		displayOrderFlag.Changed = previousDisplayOrderChanged
+	})
 
 	if err := containerCreateCmd.RunE(containerCreateCmd, []string{"app-1"}); err != nil {
 		t.Fatalf("run create: %v", err)
-	}
-}
-
-func TestContainerCreateKeepsLegacyGroupingWithoutDeploymentID(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost || r.URL.Path != "/api/containers" {
-			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
-		}
-		var body struct {
-			GroupName  string `json:"group_name"`
-			GroupOrder int32  `json:"group_order"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decode body: %v", err)
-		}
-		if body.GroupName != "production" || body.GroupOrder != 4 {
-			t.Fatalf("create group = (%q, %d)", body.GroupName, body.GroupOrder)
-		}
-		_, _ = io.WriteString(w, `{"id":"container-1","name":"app-1","repo":"acme/app","group_name":"production","group_order":4}`)
-	}))
-	defer server.Close()
-
-	configureDeploymentCommandTest(t, server.URL)
-	createRepo = "acme/app"
-	createTag = "v1.2.3"
-	createGroupName = "production"
-	createGroupOrder = 4
-
-	if err := containerCreateCmd.RunE(containerCreateCmd, []string{"app-1"}); err != nil {
-		t.Fatalf("run legacy create: %v", err)
 	}
 }
 

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -291,18 +291,42 @@ func configureDeploymentCommandTest(t *testing.T, serverURL string) {
 	})
 }
 
+func TestCaptureTestStdoutRestoresStdoutAfterPanic(t *testing.T) {
+	previous := os.Stdout
+	didPanic := false
+
+	func() {
+		defer func() {
+			didPanic = recover() != nil
+		}()
+		_, _ = captureTestStdout(func() error {
+			panic("test panic")
+		})
+	}()
+
+	if !didPanic {
+		t.Fatal("captureTestStdout did not propagate panic")
+	}
+	if os.Stdout != previous {
+		t.Fatal("captureTestStdout did not restore stdout after panic")
+	}
+}
+
 func captureTestStdout(run func() error) ([]byte, error) {
 	previous := os.Stdout
 	reader, writer, err := os.Pipe()
 	if err != nil {
 		return nil, err
 	}
+	defer reader.Close()
+	defer writer.Close()
 	os.Stdout = writer
+	defer func() {
+		os.Stdout = previous
+	}()
 	runErr := run()
 	closeErr := writer.Close()
-	os.Stdout = previous
 	output, readErr := io.ReadAll(reader)
-	_ = reader.Close()
 	if runErr != nil {
 		return output, runErr
 	}

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -67,7 +68,7 @@ func TestContainerGroupMovesRepositoryDeployment(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/containers":
 			_, _ = io.WriteString(w, `[{"id":"container-1","name":"app-1","repo":"acme/app","deployment_id":"deployment-1"}]`)
 		case r.Method == http.MethodGet && r.URL.Path == "/api/deployments":
-			_, _ = io.WriteString(w, `[{"id":"deployment-1","repo":"acme/app","group_order":4,"display_order":7}]`)
+			_, _ = io.WriteString(w, `[{"id":"deployment-1","repo":"acme/app","group_order":4,"display_order":7,"instance_count":3,"ready_count":2,"failed_count":1}]`)
 		case r.Method == http.MethodPut && r.URL.Path == "/api/deployments/deployment-1/group":
 			var body struct {
 				GroupName    *string `json:"group_name"`
@@ -93,8 +94,58 @@ func TestContainerGroupMovesRepositoryDeployment(t *testing.T) {
 	configureDeploymentCommandTest(t, server.URL)
 	groupName = "production"
 
-	if err := containerGroupCmd.RunE(containerGroupCmd, []string{"app-1"}); err != nil {
+	output, err := captureTestStdout(func() error {
+		return containerGroupCmd.RunE(containerGroupCmd, []string{"app-1"})
+	})
+	if err != nil {
 		t.Fatalf("run group: %v", err)
+	}
+	var updated deploymentView
+	if err := json.Unmarshal(output, &updated); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if updated.InstanceCount != 3 || updated.ReadyCount != 2 || updated.FailedCount != 1 {
+		t.Fatalf(
+			"counts = (%d, %d, %d), want (3, 2, 1)",
+			updated.InstanceCount,
+			updated.ReadyCount,
+			updated.FailedCount,
+		)
+	}
+}
+
+func TestContainerGroupFallsBackToLegacyEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/containers":
+			_, _ = io.WriteString(w, `[{"id":"container-1","name":"app-1","repo":"acme/app","group_order":4,"display_order":7}]`)
+		case r.Method == http.MethodPut && r.URL.Path == "/api/containers/container-1/group":
+			var body struct {
+				GroupName    *string `json:"group_name"`
+				GroupOrder   int32   `json:"group_order"`
+				DisplayOrder int32   `json:"display_order"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if body.GroupName == nil || *body.GroupName != "production" {
+				t.Fatalf("group_name = %v", body.GroupName)
+			}
+			if body.GroupOrder != 4 || body.DisplayOrder != 7 {
+				t.Fatalf("orders = (%d, %d), want (4, 7)", body.GroupOrder, body.DisplayOrder)
+			}
+			_, _ = io.WriteString(w, `{"id":"container-1","name":"app-1","repo":"acme/app","group_name":"production","group_order":4,"display_order":7}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	configureDeploymentCommandTest(t, server.URL)
+	groupName = "production"
+
+	if err := containerGroupCmd.RunE(containerGroupCmd, []string{"app-1"}); err != nil {
+		t.Fatalf("run legacy group: %v", err)
 	}
 }
 
@@ -151,6 +202,36 @@ func TestContainerCreateSetsDeploymentGroup(t *testing.T) {
 
 	if err := containerCreateCmd.RunE(containerCreateCmd, []string{"app-1"}); err != nil {
 		t.Fatalf("run create: %v", err)
+	}
+}
+
+func TestContainerCreateKeepsLegacyGroupingWithoutDeploymentID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/containers" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var body struct {
+			GroupName  string `json:"group_name"`
+			GroupOrder int32  `json:"group_order"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.GroupName != "production" || body.GroupOrder != 4 {
+			t.Fatalf("create group = (%q, %d)", body.GroupName, body.GroupOrder)
+		}
+		_, _ = io.WriteString(w, `{"id":"container-1","name":"app-1","repo":"acme/app","group_name":"production","group_order":4}`)
+	}))
+	defer server.Close()
+
+	configureDeploymentCommandTest(t, server.URL)
+	createRepo = "acme/app"
+	createTag = "v1.2.3"
+	createGroupName = "production"
+	createGroupOrder = 4
+
+	if err := containerCreateCmd.RunE(containerCreateCmd, []string{"app-1"}); err != nil {
+		t.Fatalf("run legacy create: %v", err)
 	}
 }
 
@@ -264,4 +345,25 @@ func configureDeploymentCommandTest(t *testing.T, serverURL string) {
 		deploymentUpdateInstanceIDs = previousUpdateInstanceIDs
 		useDebugFilter = previousUseDebugFilter
 	})
+}
+
+func captureTestStdout(run func() error) ([]byte, error) {
+	previous := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	os.Stdout = writer
+	runErr := run()
+	closeErr := writer.Close()
+	os.Stdout = previous
+	output, readErr := io.ReadAll(reader)
+	_ = reader.Close()
+	if runErr != nil {
+		return output, runErr
+	}
+	if closeErr != nil {
+		return output, closeErr
+	}
+	return output, readErr
 }

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -15,7 +15,7 @@ func TestResolveDeploymentMatchesIDAndRepository(t *testing.T) {
 			t.Fatalf("request = %s %s, want GET /api/deployments", r.Method, r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `[{"id":"deployment-1","repo":"acme/app","auto_update":"off"}]`)
+		_, _ = io.WriteString(w, `[{"id":"deployment-1","repo":"acme/app"}]`)
 	}))
 	defer server.Close()
 
@@ -31,24 +31,22 @@ func TestResolveDeploymentMatchesIDAndRepository(t *testing.T) {
 	}
 }
 
-func TestContainerAutoUpdateUsesDeploymentSettings(t *testing.T) {
+func TestDeploymentSettingsUpdatesDefaultStaging(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/containers":
-			_, _ = io.WriteString(w, `[{"id":"container-1","name":"app-1","repo":"acme/app","deployment_id":"deployment-1"}]`)
 		case r.Method == http.MethodGet && r.URL.Path == "/api/deployments":
-			_, _ = io.WriteString(w, `[{"id":"deployment-1","repo":"acme/app","auto_update":"off"}]`)
+			_, _ = io.WriteString(w, `[{"id":"deployment-1","repo":"acme/app"}]`)
 		case r.Method == http.MethodPatch && r.URL.Path == "/api/deployments/deployment-1":
 			var body struct {
-				AutoUpdate string `json:"auto_update"`
+				DefaultStaging bool `json:"default_staging"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatalf("decode body: %v", err)
 			}
-			if body.AutoUpdate != deploymentAutoUpdateLatest {
-				t.Fatalf("auto_update = %q, want %q", body.AutoUpdate, deploymentAutoUpdateLatest)
+			if !body.DefaultStaging {
+				t.Fatal("default_staging = false, want true")
 			}
-			_, _ = io.WriteString(w, `{"id":"deployment-1","repo":"acme/app","auto_update":"latest"}`)
+			_, _ = io.WriteString(w, `{"id":"deployment-1","repo":"acme/app","default_staging":true}`)
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
@@ -56,10 +54,10 @@ func TestContainerAutoUpdateUsesDeploymentSettings(t *testing.T) {
 	defer server.Close()
 
 	configureDeploymentCommandTest(t, server.URL)
-	autoUpdateOn = true
+	deploymentSettingsDefaultStaging = "true"
 
-	if err := containerAutoUpdateCmd.RunE(containerAutoUpdateCmd, []string{"app-1"}); err != nil {
-		t.Fatalf("run auto-update: %v", err)
+	if err := deploymentSettingsCmd.RunE(deploymentSettingsCmd, []string{"acme/app"}); err != nil {
+		t.Fatalf("run deployment settings: %v", err)
 	}
 }
 
@@ -69,7 +67,7 @@ func TestContainerGroupMovesRepositoryDeployment(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/containers":
 			_, _ = io.WriteString(w, `[{"id":"container-1","name":"app-1","repo":"acme/app","deployment_id":"deployment-1"}]`)
 		case r.Method == http.MethodGet && r.URL.Path == "/api/deployments":
-			_, _ = io.WriteString(w, `[{"id":"deployment-1","repo":"acme/app","group_order":4,"display_order":7,"auto_update":"off"}]`)
+			_, _ = io.WriteString(w, `[{"id":"deployment-1","repo":"acme/app","group_order":4,"display_order":7}]`)
 		case r.Method == http.MethodPut && r.URL.Path == "/api/deployments/deployment-1/group":
 			var body struct {
 				GroupName    *string `json:"group_name"`
@@ -85,7 +83,7 @@ func TestContainerGroupMovesRepositoryDeployment(t *testing.T) {
 			if body.GroupOrder != 4 || body.DisplayOrder != 7 {
 				t.Fatalf("orders = (%d, %d), want (4, 7)", body.GroupOrder, body.DisplayOrder)
 			}
-			_, _ = io.WriteString(w, `{"id":"deployment-1","repo":"acme/app","group_name":"production","group_order":4,"display_order":7,"auto_update":"off"}`)
+			_, _ = io.WriteString(w, `{"id":"deployment-1","repo":"acme/app","group_name":"production","group_order":4,"display_order":7}`)
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
@@ -121,7 +119,7 @@ func TestContainerCreateSetsDeploymentGroup(t *testing.T) {
 			}
 			_, _ = io.WriteString(w, `{"id":"container-1","name":"app-1","repo":"acme/app","deployment_id":"deployment-1"}`)
 		case r.Method == http.MethodGet && r.URL.Path == "/api/deployments":
-			_, _ = io.WriteString(w, `[{"id":"deployment-1","repo":"acme/app","display_order":7,"auto_update":"off"}]`)
+			_, _ = io.WriteString(w, `[{"id":"deployment-1","repo":"acme/app","display_order":7}]`)
 		case r.Method == http.MethodPut && r.URL.Path == "/api/deployments/deployment-1/group":
 			var body struct {
 				GroupName    *string `json:"group_name"`
@@ -137,7 +135,7 @@ func TestContainerCreateSetsDeploymentGroup(t *testing.T) {
 			if body.GroupOrder != 4 || body.DisplayOrder != 7 {
 				t.Fatalf("orders = (%d, %d), want (4, 7)", body.GroupOrder, body.DisplayOrder)
 			}
-			_, _ = io.WriteString(w, `{"id":"deployment-1","repo":"acme/app","group_name":"production","group_order":4,"display_order":7,"auto_update":"off"}`)
+			_, _ = io.WriteString(w, `{"id":"deployment-1","repo":"acme/app","group_name":"production","group_order":4,"display_order":7}`)
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
@@ -160,7 +158,7 @@ func TestDeploymentUpdateUsesDeploymentEndpoint(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/api/deployments":
-			_, _ = io.WriteString(w, `[{"id":"deployment-1","repo":"acme/app","auto_update":"off"}]`)
+			_, _ = io.WriteString(w, `[{"id":"deployment-1","repo":"acme/app"}]`)
 		case r.Method == http.MethodPost && r.URL.Path == "/api/deployments/deployment-1/update":
 			var body struct {
 				Tag         string   `json:"tag"`
@@ -218,8 +216,7 @@ func configureDeploymentCommandTest(t *testing.T, serverURL string) {
 	t.Setenv(envConfigPath, filepath.Join(t.TempDir(), "missing-config.json"))
 
 	previousOutput := outputFormat
-	previousAutoUpdateOn := autoUpdateOn
-	previousAutoUpdateOff := autoUpdateOff
+	previousSettingsDefaultStaging := deploymentSettingsDefaultStaging
 	previousGroupName := groupName
 	previousGroupUngroup := groupUngroup
 	previousGroupOrder := groupOrder
@@ -235,8 +232,7 @@ func configureDeploymentCommandTest(t *testing.T, serverURL string) {
 	previousUseDebugFilter := useDebugFilter
 
 	outputFormat = "json"
-	autoUpdateOn = false
-	autoUpdateOff = false
+	deploymentSettingsDefaultStaging = ""
 	groupName = ""
 	groupUngroup = false
 	groupOrder = 0
@@ -253,8 +249,7 @@ func configureDeploymentCommandTest(t *testing.T, serverURL string) {
 
 	t.Cleanup(func() {
 		outputFormat = previousOutput
-		autoUpdateOn = previousAutoUpdateOn
-		autoUpdateOff = previousAutoUpdateOff
+		deploymentSettingsDefaultStaging = previousSettingsDefaultStaging
 		groupName = previousGroupName
 		groupUngroup = previousGroupUngroup
 		groupOrder = previousGroupOrder

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds repository deployment management to the CLI and routes grouping and updates through deployments. Drops container auto-update and requires deployment-aware controlplanes; CLI errors now print to stderr.

- **New Features**
  - New `tinfoil deployment` commands: `list`, `get`, `settings` (supports `--default-staging`), `group`, `update`.
  - `deployment update` supports `--tag`, `--staging true|false`, and `--instance`; prints per-instance results and errors if any fail/skip.
  - `tinfoil container group` now moves the repository deployment; flags set deployment ordering.
  - `tinfoil container create` applies group flags to the deployment; `--display-order` can be set without a group.
  - Container view shows `Deployment ID` when available.
  - Legacy support: if a container lacks `deployment_id`, resolve the deployment by `repo`; deployment counts are preserved in outputs.

- **Migration**
  - Removed `tinfoil container auto-update` and README references.
  - Use `tinfoil deployment update --tag <tag> [--staging true|false] [--instance <id>]` instead.
  - Requires deployment-aware controlplanes (`/api/deployments*` endpoints).

<sup>Written for commit d9414b9d446d5038134bd4b34cfeadd40d873ac5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-cli/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

