### PR TITLE
feat: manage repository-scoped secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ tinfoil certificate audit -c /path/to/certificate.pem
 
 ## Container management
 
-The `container`, `secret`, `ssh-key`, `registry`, and `domain` subcommands manage Tinfoil Containers through the same controlplane API the dashboard uses. See the [Tinfoil Containers docs](https://docs.tinfoil.sh/containers/overview) for the underlying concepts and the [CLI reference](https://docs.tinfoil.sh/containers/cli) for the full command surface.
+The `container`, `repo`, `secret`, `ssh-key`, `registry`, and `domain` subcommands manage Tinfoil Containers through the same controlplane API the dashboard uses. See the [Tinfoil Containers docs](https://docs.tinfoil.sh/containers/overview) for the underlying concepts and the [CLI reference](https://docs.tinfoil.sh/containers/cli) for the full command surface.
 
 ### Logging in
 
@@ -203,6 +203,12 @@ tinfoil secret list
 echo -n "$OPENAI_KEY" | tinfoil secret create OPENAI_API_KEY --value-file -
 tinfoil secret set OPENAI_API_KEY --value-file ./key.txt
 tinfoil secret delete OPENAI_API_KEY
+
+# Repository secrets
+tinfoil repo secret list screenpipe/my-repo-container
+tinfoil repo secret create screenpipe/my-repo-container OPENAI_API_KEY --value-file ./key.txt
+tinfoil repo secret set screenpipe/my-repo-container OPENAI_API_KEY --value-file ./key.txt
+tinfoil repo secret delete screenpipe/my-repo-container OPENAI_API_KEY
 
 # SSH keys for debug containers
 tinfoil ssh-key create laptop --public-key-file ~/.ssh/id_ed25519.pub

--- a/repo_secret.go
+++ b/repo_secret.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	repoCmd.AddCommand(repoSecretCmd)
+	repoSecretCmd.AddCommand(
+		repoSecretListCmd,
+		repoSecretGetCmd,
+		repoSecretCreateCmd,
+		repoSecretSetCmd,
+		repoSecretDeleteCmd,
+	)
+	for _, cmd := range []*cobra.Command{repoSecretCreateCmd, repoSecretSetCmd} {
+		cmd.Flags().StringVar(&secretValue, "value", "", "Secret value (use --value-file or stdin to avoid leaking via process listing)")
+		cmd.Flags().StringVar(&secretValueFile, "value-file", "", "Read the secret value from this file (use - for stdin)")
+	}
+	silenceUsageRecursive(repoSecretCmd)
+}
+
+var repoSecretCmd = &cobra.Command{
+	Use:     "secret",
+	Aliases: []string{"secrets"},
+	Short:   "Manage repository-level secrets",
+}
+
+var repoSecretListCmd = &cobra.Command{
+	Use:     "list [owner/repo]",
+	Aliases: []string{"ls"},
+	Short:   "List secrets for a repository",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		repository, client, err := repositoryCommand(args[0])
+		if err != nil {
+			return err
+		}
+		list, err := listSecrets(client, repository.secretsAPIPath())
+		if err != nil {
+			return err
+		}
+		return printSecretList(list)
+	},
+}
+
+var repoSecretGetCmd = &cobra.Command{
+	Use:   "get [owner/repo] [name]",
+	Short: "Show repository secret metadata",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		repository, client, err := repositoryCommand(args[0])
+		if err != nil {
+			return err
+		}
+		secret, err := getSecret(client, repository.secretAPIPath(args[1]))
+		if err != nil {
+			return err
+		}
+		return printSecret(secret)
+	},
+}
+
+var repoSecretCreateCmd = &cobra.Command{
+	Use:   "create [owner/repo] [name]",
+	Short: "Create a repository secret",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		repository, client, err := repositoryCommand(args[0])
+		if err != nil {
+			return err
+		}
+		value, err := readSecretValue(cmd)
+		if err != nil {
+			return err
+		}
+		secret, err := createSecret(client, repository.secretsAPIPath(), args[1], value)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Created repository secret %s\n", secret.Name)
+		return nil
+	},
+}
+
+var repoSecretSetCmd = &cobra.Command{
+	Use:   "set [owner/repo] [name]",
+	Short: "Update a repository secret",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		repository, client, err := repositoryCommand(args[0])
+		if err != nil {
+			return err
+		}
+		value, err := readSecretValue(cmd)
+		if err != nil {
+			return err
+		}
+		secret, err := setSecret(client, repository.secretAPIPath(args[1]), value)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Updated repository secret %s (matching containers will be marked stale)\n", secret.Name)
+		return nil
+	},
+}
+
+var repoSecretDeleteCmd = &cobra.Command{
+	Use:     "delete [owner/repo] [name]",
+	Aliases: []string{"rm", "remove"},
+	Short:   "Delete a repository secret",
+	Args:    cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		repository, client, err := repositoryCommand(args[0])
+		if err != nil {
+			return err
+		}
+		if err := deleteSecret(client, repository.secretAPIPath(args[1])); err != nil {
+			return err
+		}
+		fmt.Printf("Deleted repository secret %s\n", args[1])
+		return nil
+	},
+}
+
+func (r repositoryRef) secretsAPIPath() string {
+	return pathf("/api/repositories/%s/%s/secrets", r.owner, r.name)
+}
+
+func (r repositoryRef) secretAPIPath(name string) string {
+	return pathf("/api/repositories/%s/%s/secrets/%s", r.owner, r.name, name)
+}

--- a/repo_secret_test.go
+++ b/repo_secret_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRepoSecretCommandsUseScopedEndpoints(t *testing.T) {
+	type requestExpectation struct {
+		method string
+		path   string
+		body   map[string]string
+		result string
+	}
+	expectations := []requestExpectation{
+		{
+			method: http.MethodGet,
+			path:   "/api/repositories/acme/app/secrets",
+			result: `[{"id":"one","name":"DATABASE_URL","scope":"repo","updated_at":"2026-07-10T00:00:00Z"}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/api/repositories/acme/app/secrets/DATABASE_URL",
+			result: `{"id":"one","name":"DATABASE_URL","scope":"repo","updated_at":"2026-07-10T00:00:00Z"}`,
+		},
+		{
+			method: http.MethodPost,
+			path:   "/api/repositories/acme/app/secrets",
+			body:   map[string]string{"name": "DATABASE_URL", "value": "create-value"},
+			result: `{"id":"one","name":"DATABASE_URL","scope":"repo"}`,
+		},
+		{
+			method: http.MethodPut,
+			path:   "/api/repositories/acme/app/secrets/DATABASE_URL",
+			body:   map[string]string{"value": "update-value"},
+			result: `{"id":"one","name":"DATABASE_URL","scope":"repo"}`,
+		},
+		{
+			method: http.MethodDelete,
+			path:   "/api/repositories/acme/app/secrets/DATABASE_URL",
+			result: `{"message":"secret deleted"}`,
+		},
+	}
+	requestIndex := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requestIndex >= len(expectations) {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		expectation := expectations[requestIndex]
+		requestIndex++
+		if r.Method != expectation.method {
+			t.Errorf("method = %s, want %s", r.Method, expectation.method)
+		}
+		if r.URL.Path != expectation.path {
+			t.Errorf("path = %q, want %q", r.URL.Path, expectation.path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer admin_test" {
+			t.Errorf("authorization = %q", got)
+		}
+		if expectation.body != nil {
+			var body map[string]string
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+			}
+			for key, want := range expectation.body {
+				if body[key] != want {
+					t.Errorf("body[%q] = %q, want %q", key, body[key], want)
+				}
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, expectation.result)
+	}))
+	defer server.Close()
+
+	configureRepoCommandTest(t, server.URL)
+	configureRepoSecretValueTest(t)
+
+	if err := repoSecretListCmd.RunE(repoSecretListCmd, []string{"acme/app"}); err != nil {
+		t.Fatalf("list repository secrets: %v", err)
+	}
+	if err := repoSecretGetCmd.RunE(repoSecretGetCmd, []string{"acme/app", "DATABASE_URL"}); err != nil {
+		t.Fatalf("get repository secret: %v", err)
+	}
+	secretValue = "create-value"
+	repoSecretCreateCmd.Flags().Lookup("value").Changed = true
+	if err := repoSecretCreateCmd.RunE(repoSecretCreateCmd, []string{"acme/app", "DATABASE_URL"}); err != nil {
+		t.Fatalf("create repository secret: %v", err)
+	}
+	secretValue = "update-value"
+	repoSecretSetCmd.Flags().Lookup("value").Changed = true
+	if err := repoSecretSetCmd.RunE(repoSecretSetCmd, []string{"acme/app", "DATABASE_URL"}); err != nil {
+		t.Fatalf("update repository secret: %v", err)
+	}
+	if err := repoSecretDeleteCmd.RunE(repoSecretDeleteCmd, []string{"acme/app", "DATABASE_URL"}); err != nil {
+		t.Fatalf("delete repository secret: %v", err)
+	}
+	if requestIndex != len(expectations) {
+		t.Fatalf("received %d requests, want %d", requestIndex, len(expectations))
+	}
+}
+
+func TestRepoSecretScopeAndPathEscaping(t *testing.T) {
+	repository, err := parseRepository("acme/my app")
+	if err != nil {
+		t.Fatalf("parse repository: %v", err)
+	}
+	if got, want := repository.secretAPIPath("token/name"), "/api/repositories/acme/my%20app/secrets/token%2Fname"; got != want {
+		t.Fatalf("secret path = %q, want %q", got, want)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `[{"id":"one","name":"TOKEN","scope":"repo"}]`)
+	}))
+	defer server.Close()
+	client := &cpClient{baseURL: server.URL, http: server.Client()}
+	secrets, err := listSecrets(client, "/api/repositories/acme/app/secrets")
+	if err != nil {
+		t.Fatalf("list repository secrets: %v", err)
+	}
+	if len(secrets) != 1 || secrets[0].Scope != "repo" {
+		t.Fatalf("scope = %#v, want repo", secrets)
+	}
+}
+
+func TestRepoSecretRejectsInvalidRepository(t *testing.T) {
+	if err := repoSecretListCmd.RunE(repoSecretListCmd, []string{"missing-owner"}); err == nil {
+		t.Fatal("expected repository validation error")
+	}
+}
+
+func configureRepoSecretValueTest(t *testing.T) {
+	t.Helper()
+	previousValue := secretValue
+	previousFile := secretValueFile
+	createValueChanged := repoSecretCreateCmd.Flags().Lookup("value").Changed
+	createFileChanged := repoSecretCreateCmd.Flags().Lookup("value-file").Changed
+	setValueChanged := repoSecretSetCmd.Flags().Lookup("value").Changed
+	setFileChanged := repoSecretSetCmd.Flags().Lookup("value-file").Changed
+	secretValue = ""
+	secretValueFile = ""
+	t.Cleanup(func() {
+		secretValue = previousValue
+		secretValueFile = previousFile
+		repoSecretCreateCmd.Flags().Lookup("value").Changed = createValueChanged
+		repoSecretCreateCmd.Flags().Lookup("value-file").Changed = createFileChanged
+		repoSecretSetCmd.Flags().Lookup("value").Changed = setValueChanged
+		repoSecretSetCmd.Flags().Lookup("value-file").Changed = setFileChanged
+	})
+}

--- a/secret.go
+++ b/secret.go
@@ -12,6 +12,7 @@ import (
 type secretView struct {
 	ID        string   `json:"id"`
 	Name      string   `json:"name"`
+	Scope     string   `json:"scope"`
 	CreatedAt string   `json:"created_at"`
 	UpdatedAt string   `json:"updated_at"`
 	UsedBy    []string `json:"used_by"`
@@ -51,26 +52,11 @@ var secretListCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		var list []secretView
-		if _, err := client.do("GET", "/api/secrets", nil, nil, &list); err != nil {
+		list, err := listSecrets(client, "/api/secrets")
+		if err != nil {
 			return err
 		}
-		if outputFormat == "json" {
-			return printJSON(list)
-		}
-		if len(list) == 0 {
-			fmt.Println("No secrets.")
-			return nil
-		}
-		fmt.Printf("%-32s  %-30s  %s\n", "NAME", "UPDATED", "USED BY")
-		for _, s := range list {
-			used := strings.Join(s.UsedBy, ", ")
-			if used == "" {
-				used = "-"
-			}
-			fmt.Printf("%-32s  %-30s  %s\n", truncate(s.Name, 32), truncate(s.UpdatedAt, 30), used)
-		}
-		return nil
+		return printSecretList(list)
 	},
 }
 
@@ -83,23 +69,11 @@ var secretGetCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		var s secretView
-		if _, err := client.do("GET", pathf("/api/secrets/%s", args[0]), nil, nil, &s); err != nil {
+		s, err := getSecret(client, pathf("/api/secrets/%s", args[0]))
+		if err != nil {
 			return err
 		}
-		if outputFormat == "json" {
-			return printJSON(s)
-		}
-		fmt.Printf("Name:      %s\n", s.Name)
-		fmt.Printf("ID:        %s\n", s.ID)
-		fmt.Printf("Created:   %s\n", s.CreatedAt)
-		fmt.Printf("Updated:   %s\n", s.UpdatedAt)
-		used := strings.Join(s.UsedBy, ", ")
-		if used == "" {
-			used = "-"
-		}
-		fmt.Printf("Used by:   %s\n", used)
-		return nil
+		return printSecret(s)
 	},
 }
 
@@ -116,9 +90,8 @@ var secretCreateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		body := map[string]any{"name": args[0], "value": value}
-		var s secretView
-		if _, err := client.do("POST", "/api/secrets", nil, body, &s); err != nil {
+		s, err := createSecret(client, "/api/secrets", args[0], value)
+		if err != nil {
 			return err
 		}
 		fmt.Printf("Created secret %s\n", s.Name)
@@ -139,9 +112,8 @@ var secretSetCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		body := map[string]any{"value": value}
-		var s secretView
-		if _, err := client.do("PUT", pathf("/api/secrets/%s", args[0]), nil, body, &s); err != nil {
+		s, err := setSecret(client, pathf("/api/secrets/%s", args[0]), value)
+		if err != nil {
 			return err
 		}
 		fmt.Printf("Updated secret %s (containers using it will be marked stale)\n", s.Name)
@@ -159,12 +131,86 @@ var secretDeleteCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if _, err := client.do("DELETE", pathf("/api/secrets/%s", args[0]), nil, nil, nil); err != nil {
+		if err := deleteSecret(client, pathf("/api/secrets/%s", args[0])); err != nil {
 			return err
 		}
 		fmt.Printf("Deleted secret %s\n", args[0])
 		return nil
 	},
+}
+
+func listSecrets(client *cpClient, path string) ([]secretView, error) {
+	var list []secretView
+	if _, err := client.do("GET", path, nil, nil, &list); err != nil {
+		return nil, err
+	}
+	return list, nil
+}
+
+func getSecret(client *cpClient, path string) (secretView, error) {
+	var secret secretView
+	if _, err := client.do("GET", path, nil, nil, &secret); err != nil {
+		return secretView{}, err
+	}
+	return secret, nil
+}
+
+func createSecret(client *cpClient, path, name, value string) (secretView, error) {
+	var secret secretView
+	body := map[string]any{"name": name, "value": value}
+	if _, err := client.do("POST", path, nil, body, &secret); err != nil {
+		return secretView{}, err
+	}
+	return secret, nil
+}
+
+func setSecret(client *cpClient, path, value string) (secretView, error) {
+	var secret secretView
+	body := map[string]any{"value": value}
+	if _, err := client.do("PUT", path, nil, body, &secret); err != nil {
+		return secretView{}, err
+	}
+	return secret, nil
+}
+
+func deleteSecret(client *cpClient, path string) error {
+	_, err := client.do("DELETE", path, nil, nil, nil)
+	return err
+}
+
+func printSecretList(list []secretView) error {
+	if outputFormat == "json" {
+		return printJSON(list)
+	}
+	if len(list) == 0 {
+		fmt.Println("No secrets.")
+		return nil
+	}
+	fmt.Printf("%-32s  %-30s  %s\n", "NAME", "UPDATED", "USED BY")
+	for _, secret := range list {
+		used := strings.Join(secret.UsedBy, ", ")
+		if used == "" {
+			used = "-"
+		}
+		fmt.Printf("%-32s  %-30s  %s\n", truncate(secret.Name, 32), truncate(secret.UpdatedAt, 30), used)
+	}
+	return nil
+}
+
+func printSecret(secret secretView) error {
+	if outputFormat == "json" {
+		return printJSON(secret)
+	}
+	fmt.Printf("Name:      %s\n", secret.Name)
+	fmt.Printf("ID:        %s\n", secret.ID)
+	fmt.Printf("Created:   %s\n", secret.CreatedAt)
+	fmt.Printf("Updated:   %s\n", secret.UpdatedAt)
+	used := strings.Join(secret.UsedBy, ", ")
+	if used == "" {
+		used = "-"
+	}
+	fmt.Printf("Used by:   %s\n", used)
+	return nil
 }
 
 // readSecretValue resolves the secret value from --value, --value-file, or


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds CLI support for repository-scoped secrets via `tinfoil repo secret` commands and refactors shared secret helpers for reuse. This lets users manage secrets per repository and keeps the code DRY.

- **New Features**
  - Add `repo secret` subcommands: list, get, create, set, delete for `[owner/repo]`.
  - Use repo-scoped API paths with proper path escaping.
  - Support `--value` and `--value-file` for create/set.
  - Update README with repo-secret examples and add tests for endpoints, escaping, and invalid input.

- **Refactors**
  - Extract shared helpers: listSecrets, getSecret, createSecret, setSecret, deleteSecret, printSecret, printSecretList.
  - Add `Scope` to `secretView` and unify output logic.
  - Reuse helpers in existing global `secret` commands.

<sup>Written for commit e7c7493a785c69f53856e0f94e4cb46e59a06258. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/tinfoil-cli/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

