### PR TITLE
feat: manage prepared models

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,18 @@ tinfoil container connect my-container -p 8080
 
 `container connect <name>` resolves the container's enclave domain and source repo, then runs a verified proxy locally — equivalent to `tinfoil proxy -e <domain> -r <repo>` but without copy-pasting either value.
 
+### Prepared models
+
+List modelwrap jobs and delete a terminal job together with its unshared model artifact and download cache:
+
+```bash
+tinfoil model list
+tinfoil model delete <job-id>
+tinfoil model delete owner/model@revision --host <host-name>
+```
+
+Deletion is rejected while a wrap is running or while its artifact is referenced by a container deployment.
+
 ### Secrets, SSH keys, registry credentials, custom domains
 
 ```bash

--- a/model.go
+++ b/model.go
@@ -162,10 +162,10 @@ func renderModelwraps(models []modelwrapView) error {
 		fmt.Println("No prepared models.")
 		return nil
 	}
-	fmt.Printf("%-12s  %-20s  %-10s  %-48s  %s\n", "JOB ID", "HOST", "STATUS", "MODEL", "STARTED")
+	fmt.Printf("%-16s  %-20s  %-10s  %-48s  %s\n", "JOB ID", "HOST", "STATUS", "MODEL", "STARTED")
 	for _, model := range models {
-		fmt.Printf("%-12s  %-20s  %-10s  %-48s  %s\n",
-			truncate(model.ID, 12), truncate(model.Host, 20), model.Status,
+		fmt.Printf("%-16s  %-20s  %-10s  %-48s  %s\n",
+			truncate(model.ID, 16), truncate(model.Host, 20), model.Status,
 			truncate(modelwrapTarget(model), 48), model.StartedAt,
 		)
 	}

--- a/model.go
+++ b/model.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type modelwrapView struct {
+	ID         string `json:"id"`
+	JobID      string `json:"job_id"`
+	RecordID   string `json:"record_id"`
+	Host       string `json:"host"`
+	Repo       string `json:"repo"`
+	Commit     string `json:"commit"`
+	Status     string `json:"status"`
+	Error      string `json:"error,omitempty"`
+	RootHash   string `json:"root_hash,omitempty"`
+	Offset     int64  `json:"offset,omitempty"`
+	VerityUUID string `json:"verity_uuid,omitempty"`
+	StartedAt  string `json:"started_at"`
+	EndedAt    string `json:"ended_at,omitempty"`
+}
+
+var (
+	modelOutputFormat string
+	modelListLimit    int
+	modelDeleteHost   string
+)
+
+func init() {
+	rootCmd.AddCommand(modelCmd)
+	modelCmd.PersistentFlags().StringVarP(&modelOutputFormat, "output", "o", "table", "Output format: table or json")
+	modelCmd.AddCommand(modelListCmd)
+	modelCmd.AddCommand(modelDeleteCmd)
+	modelListCmd.Flags().IntVar(&modelListLimit, "limit", 20, "Maximum number of model wraps to return (1-200)")
+	modelDeleteCmd.Flags().StringVar(&modelDeleteHost, "host", "", "Host name, used to disambiguate duplicate model wraps")
+	silenceUsageRecursive(modelCmd)
+}
+
+var modelCmd = &cobra.Command{
+	Use:          "model",
+	Aliases:      []string{"models"},
+	Short:        "Manage prepared model weights",
+	SilenceUsage: true,
+}
+
+var modelListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List prepared model weights in the current organization",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if modelListLimit < 1 || modelListLimit > 200 {
+			return fmt.Errorf("--limit must be between 1 and 200")
+		}
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		models, err := listModelwraps(client, modelListLimit)
+		if err != nil {
+			return err
+		}
+		return renderModelwraps(models)
+	},
+}
+
+var modelDeleteCmd = &cobra.Command{
+	Use:     "delete [job-id|owner/model@revision]",
+	Aliases: []string{"rm", "remove"},
+	Short:   "Delete prepared model weights",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := authedClient()
+		if err != nil {
+			return err
+		}
+		deleted, err := deleteModelwrap(client, args[0], modelDeleteHost)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Deleted model %s from %s (job %s)\n", modelwrapTarget(deleted), deleted.Host, deleted.ID)
+		return nil
+	},
+}
+
+func listModelwraps(client *cpClient, limit int) ([]modelwrapView, error) {
+	query := url.Values{"limit": []string{fmt.Sprintf("%d", limit)}}
+	var models []modelwrapView
+	if _, err := client.do(http.MethodGet, "/api/models/wrap", query, nil, &models); err != nil {
+		return nil, err
+	}
+	for i := range models {
+		if models[i].JobID != "" {
+			models[i].ID = models[i].JobID
+		}
+	}
+	return models, nil
+}
+
+func deleteModelwrap(client *cpClient, identifier, host string) (modelwrapView, error) {
+	models, err := listModelwraps(client, 200)
+	if err != nil {
+		return modelwrapView{}, err
+	}
+	model, err := resolveModelwrapFromList(models, identifier, host)
+	if err != nil {
+		return modelwrapView{}, err
+	}
+	if _, err := client.do(
+		http.MethodDelete,
+		pathf("/api/models/wrap/%s/%s", model.Host, model.ID),
+		nil,
+		nil,
+		nil,
+	); err != nil {
+		return modelwrapView{}, err
+	}
+	return model, nil
+}
+
+func resolveModelwrapFromList(models []modelwrapView, identifier, host string) (modelwrapView, error) {
+	identifier = strings.TrimSpace(identifier)
+	host = strings.TrimSpace(host)
+	if identifier == "" {
+		return modelwrapView{}, fmt.Errorf("model identifier is empty")
+	}
+	matches := make([]modelwrapView, 0, 2)
+	for _, model := range models {
+		if host != "" && model.Host != host {
+			continue
+		}
+		if model.ID == identifier || model.JobID == identifier || model.RecordID == identifier || modelwrapTarget(model) == identifier {
+			matches = append(matches, model)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return modelwrapView{}, fmt.Errorf("no model wrap matching %q", identifier)
+	case 1:
+		return matches[0], nil
+	default:
+		return modelwrapView{}, fmt.Errorf("multiple model wraps match %q; use the job ID or pass --host", identifier)
+	}
+}
+
+func modelwrapTarget(model modelwrapView) string {
+	if model.Commit == "" {
+		return model.Repo
+	}
+	return model.Repo + "@" + model.Commit
+}
+
+func renderModelwraps(models []modelwrapView) error {
+	if modelOutputFormat == "json" {
+		return printJSON(models)
+	}
+	if len(models) == 0 {
+		fmt.Println("No prepared models.")
+		return nil
+	}
+	fmt.Printf("%-12s  %-20s  %-10s  %-48s  %s\n", "JOB ID", "HOST", "STATUS", "MODEL", "STARTED")
+	for _, model := range models {
+		fmt.Printf("%-12s  %-20s  %-10s  %-48s  %s\n",
+			truncate(model.ID, 12), truncate(model.Host, 20), model.Status,
+			truncate(modelwrapTarget(model), 48), model.StartedAt,
+		)
+	}
+	return nil
+}

--- a/model_test.go
+++ b/model_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDeleteModelwrapUsesResolvedHostAndJob(t *testing.T) {
+	request := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request++
+		switch request {
+		case 1:
+			if r.Method != http.MethodGet || r.URL.Path != "/api/models/wrap" || r.URL.Query().Get("limit") != "200" {
+				t.Errorf("list request = %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+			}
+			_, _ = io.WriteString(w, `[{"id":"job-1","job_id":"job-1","host":"gpu-a","repo":"org/model","commit":"abcdef1","status":"complete"}]`)
+		case 2:
+			if r.Method != http.MethodDelete || r.URL.Path != "/api/models/wrap/gpu-a/job-1" {
+				t.Errorf("delete request = %s %s", r.Method, r.URL.Path)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected request %d: %s %s", request, r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := &cpClient{baseURL: server.URL, apiKey: "admin_test", http: server.Client()}
+	deleted, err := deleteModelwrap(client, "org/model@abcdef1", "")
+	if err != nil {
+		t.Fatalf("deleteModelwrap: %v", err)
+	}
+	if deleted.ID != "job-1" || deleted.Host != "gpu-a" {
+		t.Fatalf("deleted = %#v", deleted)
+	}
+	if request != 2 {
+		t.Fatalf("requests = %d, want 2", request)
+	}
+}
+
+func TestResolveModelwrapRequiresDisambiguation(t *testing.T) {
+	models := []modelwrapView{
+		{ID: "job-1", Host: "gpu-a", Repo: "org/model", Commit: "abcdef1"},
+		{ID: "job-2", Host: "gpu-b", Repo: "org/model", Commit: "abcdef1"},
+	}
+	if _, err := resolveModelwrapFromList(models, "org/model@abcdef1", ""); err == nil {
+		t.Fatal("expected ambiguous model target to fail")
+	}
+	got, err := resolveModelwrapFromList(models, "org/model@abcdef1", "gpu-b")
+	if err != nil {
+		t.Fatalf("resolve with host: %v", err)
+	}
+	if got.ID != "job-2" {
+		t.Fatalf("resolved job = %s, want job-2", got.ID)
+	}
+}


### PR DESCRIPTION
Adds `tinfoil model list` and `tinfoil model delete`. Models can be deleted by job ID or `owner/model@revision`, with `--host` to disambiguate duplicates.